### PR TITLE
Replacing pin_created with pin_hash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
   
 * `pin_upload()` now better handles path expansion (#585, @sellorm).
 
+* The `pin_reactive_*()` functions now use the hash (rather than the created 
+  date) for polling (#595, @thomaszwagerman).
+
 # pins 1.0.1
 
 * `board_azure()` now allows you to set a `path` so that multiple boards can

--- a/R/pin_reactive.R
+++ b/R/pin_reactive.R
@@ -72,7 +72,7 @@ pin_reactive_read <- function(board, name, interval = 5000) {
   shiny::reactivePoll(
     intervalMillis = interval,
     session = shiny::getDefaultReactiveDomain(),
-    checkFunc = function() pin_created(board, name),
+    checkFunc = function() pin_hash(board, name),
     valueFunc = function() pin_read(board, name)
   )
 }
@@ -85,12 +85,12 @@ pin_reactive_download <- function(board, name, interval = 5000) {
   shiny::reactivePoll(
     intervalMillis = interval,
     session = shiny::getDefaultReactiveDomain(),
-    checkFunc = function() pin_created(board, name),
+    checkFunc = function() pin_hash(board, name),
     valueFunc = function() pin_download(board, name)
   )
 }
 
-pin_created <- function(board, name) {
+pin_hash <- function(board, name){
   meta <- pin_meta(board, name)
-  meta$created
+  meta$pin_hash
 }

--- a/R/pin_reactive.R
+++ b/R/pin_reactive.R
@@ -72,7 +72,7 @@ pin_reactive_read <- function(board, name, interval = 5000) {
   shiny::reactivePoll(
     intervalMillis = interval,
     session = shiny::getDefaultReactiveDomain(),
-    checkFunc = function() pin_hash(board, name),
+    checkFunc = function() get_pin_hash(board, name),
     valueFunc = function() pin_read(board, name)
   )
 }
@@ -85,12 +85,12 @@ pin_reactive_download <- function(board, name, interval = 5000) {
   shiny::reactivePoll(
     intervalMillis = interval,
     session = shiny::getDefaultReactiveDomain(),
-    checkFunc = function() pin_hash(board, name),
+    checkFunc = function() get_pin_hash(board, name),
     valueFunc = function() pin_download(board, name)
   )
 }
 
-pin_hash <- function(board, name){
+get_pin_hash <- function(board, name){
   meta <- pin_meta(board, name)
   meta$pin_hash
 }


### PR DESCRIPTION
Replaces `pin_created()` with `pin_hash()`, which supports functionality of `pin_reactive_read()` and `pin_reactive_download()`.

Suggestion made by @TylerGrantSmith.

Closes #542 