### PR TITLE
Fixes a reference to incorrect RSC version

### DIFF
--- a/vignettes/rsc.Rmd
+++ b/vignettes/rsc.Rmd
@@ -74,7 +74,7 @@ cat(readLines("rsc-automate.txt"), sep = "\n")
 ```
 
 Then publish it to RSC, and schedule it to run as often as you like.
-Assuming that you have RSC 1.8.8 or later you don't need to provide any arguments to `board_rsconnect()`; pins will automatically publish to the same Connect instance that's running the report.
+Assuming that you have RSC 1.9.0 or later you don't need to provide any arguments to `board_rsconnect()`; pins will automatically publish to the same Connect instance that's running the report.
 
 ## Shiny apps
 


### PR DESCRIPTION
RStudio Connect 1.8.8 introduced the auto-provisioning of CONNECT_API_KEY, but it was not until 1.9.0 that CONNECT_SERVER also become available.

Since not having CONNECT_SERVER specified breaks pins `auth="envvar"`, this PR changes the references to the proper version. 