### PR TITLE
Change repo to "pins-r"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,8 +14,8 @@ Description: Publish data sets, models, and other R objects, making it
     share on a networked drive or with 'DropBox'), 'RStudio' connect,
     Amazon S3, and more.
 License: Apache License (>= 2)
-URL: https://pins.rstudio.com/, https://github.com/rstudio/pins
-BugReports: https://github.com/rstudio/pins/issues
+URL: https://pins.rstudio.com/, https://github.com/rstudio/pins-r
+BugReports: https://github.com/rstudio/pins-r/issues
 Depends: 
     R (>= 3.3.0)
 Imports:

--- a/R/board_url.R
+++ b/R/board_url.R
@@ -25,9 +25,9 @@
 #' @examples
 #' github_raw <- "https://raw.githubusercontent.com/"
 #' board <- board_url(c(
-#'   files = paste0(github_raw, "rstudio/pins/master/tests/testthat/pin-files/"),
-#'   rds = paste0(github_raw, "rstudio/pins/master/tests/testthat/pin-rds/"),
-#'   raw = paste0(github_raw, "rstudio/pins/master/tests/testthat/pin-files/first.txt")
+#'   files = paste0(github_raw, "rstudio/pins-r/master/tests/testthat/pin-files/"),
+#'   rds = paste0(github_raw, "rstudio/pins-r/master/tests/testthat/pin-rds/"),
+#'   raw = paste0(github_raw, "rstudio/pins-r/master/tests/testthat/pin-files/first.txt")
 #' ))
 #'
 #' board %>% pin_read("rds")

--- a/R/legacy_datatxt.R
+++ b/R/legacy_datatxt.R
@@ -502,7 +502,7 @@ local_legacy_datatxt <- function(..., env = parent.frame()) {
 
   board_register_datatxt(
     ...,
-    url = "https://raw.githubusercontent.com/rstudio/pins/master/tests/testthat/datatxt/data.txt",
+    url = "https://raw.githubusercontent.com/rstudio/pins-r/master/tests/testthat/datatxt/data.txt",
     cache = path
   )
 }

--- a/README.Rmd
+++ b/README.Rmd
@@ -19,9 +19,9 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/rstudio/pins/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/pins/actions) 
+[![R-CMD-check](https://github.com/rstudio/pins-r/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/pins-r/actions) 
 [![CRAN Status](https://www.r-pkg.org/badges/version/pins)](https://cran.r-project.org/package=pins) 
-[![Codecov test coverage](https://codecov.io/gh/rstudio/pins/branch/main/graph/badge.svg)](https://app.codecov.io/gh/rstudio/pins?branch=main)
+[![Codecov test coverage](https://codecov.io/gh/rstudio/pins-r/branch/main/graph/badge.svg)](https://app.codecov.io/gh/rstudio/pins-r?branch=main)
 
 <!-- badges: end -->
 
@@ -33,18 +33,20 @@ pins 1.0.0 includes a new more explicit API and greater support for versioning.
 The legacy API (`pin()`, `pin_get()`, and `board_register()`) will continue to work, but new features will only be implemented with the new API, so we encourage you to switch to the modern API as quickly as possible.
 Learn more in `vignette("pins-update")`.
 
+You can use pins from Python as well as R. For example, you can use one language to read a pin created with the other. Learn more about [pins for Python](https://rstudio.github.io/pins-python/).
+
 ## Installation
 
-To try out the development version of pins (which will become pins 1.0.0 when released), you'll need to install from GitHub:
-
-```{r, eval = FALSE}
-remotes::install_github("rstudio/pins")
-```
-
-If you discover this breaks any of your existing code, please [let us know](https://github.com/rstudio/pins/issues) then revert to the released version:
+You can install pins from CRAN with:
 
 ```{r, eval = FALSE}
 install.packages("pins")
+```
+
+You can install the development version from GitHub:
+
+```{r, eval = FALSE}
+remotes::install_github("rstudio/pins-r")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 
 <!-- badges: start -->
 
-[![R-CMD-check](https://github.com/rstudio/pins/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/pins/actions)
+[![R-CMD-check](https://github.com/rstudio/pins-r/workflows/R-CMD-check/badge.svg)](https://github.com/rstudio/pins-r/actions)
 [![CRAN
 Status](https://www.r-pkg.org/badges/version/pins)](https://cran.r-project.org/package=pins)
 [![Codecov test
-coverage](https://codecov.io/gh/rstudio/pins/branch/main/graph/badge.svg)]( https://app.codecov.io/gh/rstudio/pins?branch=main)
+coverage](https://codecov.io/gh/rstudio/pins-r/branch/main/graph/badge.svg)](https://app.codecov.io/gh/rstudio/pins-r?branch=main)
 
 <!-- badges: end -->
 
@@ -26,21 +26,22 @@ implemented with the new API, so we encourage you to switch to the
 modern API as quickly as possible. Learn more in
 `vignette("pins-update")`.
 
+You can use pins from Python as well as R. For example, you can use one
+language to read a pin created with the other. Learn more about [pins
+for Python](https://rstudio.github.io/pins-python/).
+
 ## Installation
 
-To try out the development version of pins (which will become pins 1.0.0
-when released), you’ll need to install from GitHub:
-
-``` r
-remotes::install_github("rstudio/pins")
-```
-
-If you discover this breaks any of your existing code, please [let us
-know](https://github.com/rstudio/pins/issues) then revert to the
-released version:
+You can install pins from CRAN with:
 
 ``` r
 install.packages("pins")
+```
+
+You can install the development version from GitHub:
+
+``` r
+remotes::install_github("rstudio/pins-r")
 ```
 
 ## Usage

--- a/pins-r.Rproj
+++ b/pins-r.Rproj
@@ -17,5 +17,6 @@ StripTrailingWhitespace: Yes
 
 BuildType: Package
 PackageUseDevtools: Yes
+PackageCleanBeforeInstall: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
 PackageRoxygenize: rd,collate,namespace

--- a/tests/testthat/test-board_url.R
+++ b/tests/testthat/test-board_url.R
@@ -1,6 +1,6 @@
 test_that("provides key methods", {
   board <- board_url_test(c(
-    rds = github_raw("rstudio/pins/master/tests/testthat/pin-rds/")
+    rds = github_raw("rstudio/pins-r/master/tests/testthat/pin-rds/")
   ))
 
   board %>%
@@ -14,7 +14,7 @@ test_that("provides key methods", {
 
 test_that("absent pins handled consistently", {
   board <- board_url_test(c(
-    x = github_raw("rstudio/pins/master/tests/testthat/pin-rds/")
+    x = github_raw("rstudio/pins-r/master/tests/testthat/pin-rds/")
   ))
 
   expect_equal(pin_list(board), "x")
@@ -26,7 +26,7 @@ test_that("absent pins handled consistently", {
 
 test_that("only downloads once", {
   board <- board_url_test(c(
-    rds = github_raw("rstudio/pins/master/tests/testthat/pin-rds/")
+    rds = github_raw("rstudio/pins-r/master/tests/testthat/pin-rds/")
   ))
 
   board %>%
@@ -40,7 +40,7 @@ test_that("only downloads once", {
 
 test_that("raw pins can only be downloaded", {
   board <- board_url_test(c(
-    raw = github_raw("rstudio/pins/master/tests/testthat/pin-files/first.txt")
+    raw = github_raw("rstudio/pins-r/master/tests/testthat/pin-files/first.txt")
   ))
 
   board %>%

--- a/tests/testthat/test-legacy_datatxt.R
+++ b/tests/testthat/test-legacy_datatxt.R
@@ -3,7 +3,7 @@ test_that("can board_register() a data.txt board", {
 
   board_register_datatxt(
     name = "simpletxt",
-    url = "https://raw.githubusercontent.com/rstudio/pins/master/tests/testthat/datatxt/data.txt",
+    url = "https://raw.githubusercontent.com/rstudio/pins-r/master/tests/testthat/datatxt/data.txt",
     cache = tempfile()
   )
 
@@ -33,7 +33,7 @@ test_that("can board_register() with URL", {
   skip_on_cran()
 
   board_name <- board_register(
-    "https://raw.githubusercontent.com/rstudio/pins/master/tests/testthat/datatxt/data.txt",
+    "https://raw.githubusercontent.com/rstudio/pins-r/master/tests/testthat/datatxt/data.txt",
     name = "simpletxt",
     cache = tempfile()
   )
@@ -41,7 +41,7 @@ test_that("can board_register() with URL", {
   expect_equal(board_name, "simpletxt")
 
   board_name <- board_register(
-    "https://raw.githubusercontent.com/rstudio/pins/master/tests/testthat/datatxt/data.txt",
+    "https://raw.githubusercontent.com/rstudio/pins-r/master/tests/testthat/datatxt/data.txt",
     cache = tempfile()
   )
   withr::defer(board_deregister("raw"))

--- a/tests/testthat/test-pin.R
+++ b/tests/testthat/test-pin.R
@@ -56,7 +56,7 @@ test_that("can pin a file", {
 test_that("can pin() remote CSV with URL and name", {
   board <- legacy_temp()
 
-  url <- "https://raw.githubusercontent.com/rstudio/pins/master/tests/testthat/datatxt/iris/data.csv"
+  url <- "https://raw.githubusercontent.com/rstudio/pins-r/master/tests/testthat/datatxt/iris/data.csv"
   pin <- pin(url, "iris", board = board)
 
   expect_equal(dim(read.csv(pin)), c(150, 5))

--- a/vignettes/pins-update.Rmd
+++ b/vignettes/pins-update.Rmd
@@ -84,7 +84,7 @@ Finally, you can `pin()` a url to automatically re-download it when it changes:
 
 ```{r}
 # Legacy API
-base <- "https://raw.githubusercontent.com/rstudio/pins/master/tests/testthat/"
+base <- "https://raw.githubusercontent.com/rstudio/pins-r/master/tests/testthat/"
 
 (pin(paste0(base, "pin-files/first.txt"), board = "vignette"))
 ```


### PR DESCRIPTION
This PR sets up changes needed to change the repo name to "pins-r", for parity with https://github.com/rstudio/pins-python. I tried hard to find everything that would need to be changed, but another set of eyes on this will be great. Also, the changes here will not pass CI until the repo is actually renamed.