### PR TITLE
`created_time` for Connect needs to use a different ISO8601 variant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pins (development version)
 
+* `board_rsconnect()` now correctly finds the created date for pins (#623, 
+  @bjfletcher).
+
 # pins 1.0.1
 
 * `board_azure()` now allows you to set a `path` so that multiple boards can

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -472,7 +472,7 @@ rsc_content_versions <- function(board, guid) {
 
   tibble::tibble(
     version = map_chr(json, ~ .x$id),
-    created = parse_8601_compact(map_chr(json, ~ .x$created_time)),
+    created = parse_8601(map_chr(json, ~ .x$created_time)),
     active = map_lgl(json, ~ .x$active),
     size = map_dbl(json, ~ .x$size),
   )

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -123,6 +123,7 @@ test_api_versioning <- function(board) {
     testthat::expect_equal(nrow(pin_versions(board, name)), 2)
     pin_write(board, 3, name)
     testthat::expect_equal(nrow(pin_versions(board, name)), 3)
+    testthat::expect_equal(sum(is.na((pin_versions(board, name)))), 0)
   })
 
   testthat::test_that("pin_read() returns latest version", {


### PR DESCRIPTION
`pins` seems to expect `created_time` with bundles to be in POSIXct format however we're seeing them in POSIXlt format.

RStudio Connect (on Kubernetes):
Version:	2022.05.0
Build:	v2022.05.0-0-g762d29c

This PR fixes it for us, however, we we will most probably want to implement something like this pseudocode:

1. check `created_time`
2. is it POSIXct format?
3. if yes, parse as POSIXct
4. if no, parse as POSIXlt

along with tests. But we'd like to check with you first about the approach before we implement the changes and push to this PR.