### PR TITLE
Added %S to the datetime format string to avoid loss of precision

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pins (development version)
 
+* Increased datetime precision to the second, for `pin_versions()` and related
+  functions (#642, @tomsing1).
+
 * `board_rsconnect()` now correctly finds the created date for pins (#623, 
   @bjfletcher).
   
@@ -7,7 +10,7 @@
 
 * The `pin_reactive_*()` functions now use the hash (rather than the created 
   date) for polling (#595, @thomaszwagerman).
-
+  
 # pins 1.0.1
 
 * `board_azure()` now allows you to set a `path` so that multiple boards can

--- a/R/meta.R
+++ b/R/meta.R
@@ -49,7 +49,7 @@ as_8601_compact <- function(x = Sys.time()) {
   format(x, "%Y%m%dT%H%M%SZ", tz = "UTC")
 }
 parse_8601_compact <- function(x) {
-  y <- as.POSIXct(strptime(x, "%Y%m%dT%H%M", tz = "UTC"))
+  y <- as.POSIXct(strptime(x, "%Y%m%dT%H%M%S", tz = "UTC"))
   attr(y, "tzone") <- ""
   y
 }

--- a/tests/testthat/_snaps/board_rsconnect_bundle.md
+++ b/tests/testthat/_snaps/board_rsconnect_bundle.md
@@ -34,7 +34,7 @@
         <section>
            <h3>TEST/test</h3>
            <p>
-             <b>Last updated:</b> 2021-11-11 11:39:00 &bull;
+             <b>Last updated:</b> 2021-11-11 11:39:56 &bull;
              <b>Format:</b> rds &bull;
              <b>API:</b> v1.0
            </p>


### PR DESCRIPTION
- The `parse_8601_compact` function seems to be dropping the seconds from a timestamp. Adding the `%S` part of the format string preserves them. This might fix issue #637  - at least ensuring that files written within > 1s receive a unique version number.