### PR TITLE
Update how user names are handled in Connect preview, message, error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pins (development version)
 
+* Fixed how Connect usernames are handled in messages, preview, etc (#643).
+
 # pins 1.0.2
 
 * `board_rsconnect()` now correctly finds the created date for pins (#623, 

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -234,7 +234,8 @@ pin_store.pins_board_rsconnect <- function(
 {
   # https://docs.rstudio.com/connect/1.8.0.4/cookbook/deploying/
 
-  check_name(rsc_parse_name(name)$name)
+  name <- rsc_parse_name(name)$name
+  check_name(name)
 
   versioned <- versioned %||% board$versioned
   if (!is.null(access_type)) {

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -234,8 +234,7 @@ pin_store.pins_board_rsconnect <- function(
 {
   # https://docs.rstudio.com/connect/1.8.0.4/cookbook/deploying/
 
-  name <- rsc_parse_name(name)$name
-  check_name(name)
+  check_name(rsc_parse_name(name)$name)
 
   versioned <- versioned %||% board$versioned
   if (!is.null(access_type)) {
@@ -305,7 +304,8 @@ pin_store.pins_board_rsconnect <- function(
     }
   }
 
-  paste0(board$account, "/", name)
+  name <- rsc_parse_name(name)
+  paste0(name$owner %||% board$account, "/", name$name)
 }
 
 #' @export
@@ -409,7 +409,10 @@ rsc_content_find <- function(board, name, version = NULL, warn = TRUE) {
   if (is.null(name$owner)) {
     if (length(json) > 1) {
       # TODO: Find user names and offer
-      abort(paste0("Multiple pins with name '",  name$name, "'"))
+      cli::cli_abort(c(
+        "Multiple pins with name {.val {name$name}}",
+        i = "Use a fully specified name including user name like {.val {paste0('julia/', name$name)}}"
+      ))
     }
     owner <- rsc_user_name(board, json[[1]]$owner_guid)
     name$full <- paste0(owner, "/", name$name)

--- a/R/board_rsconnect_bundle.R
+++ b/R/board_rsconnect_bundle.R
@@ -53,12 +53,14 @@ rsc_bundle_preview_create <- function(board, name, x, metadata, path) {
 
 rsc_bundle_preview_index <- function(board, name, x, metadata) {
   data_preview <- rsc_bundle_preview_data(x)
+  name <- rsc_parse_name(name)
+  owner <- name$owner %||% board$account
 
   data <- list(
     pin_files = paste0("<a href=\"", metadata$file, "\">", metadata$file, "</a>", collapse = ", "),
     data_preview = jsonlite::toJSON(data_preview, auto_unbox = TRUE),
     data_preview_style = if (is.data.frame(x)) "" else "display:none",
-    pin_name = paste0(board$account, "/", name),
+    pin_name = paste0(owner, "/", name$name),
     pin_metadata = list(
       as_yaml = yaml::as.yaml(metadata),
       date = format(parse_8601_compact(metadata$created), tz = "UTC"),


### PR DESCRIPTION
Addresses #636 

This change address the problem of ending up with pin names like `julia.silge/julia.silge/mtcars`:

``` r
library(pins)
b <- board_rsconnect()
#> Connecting to RSC 2022.07.0 at <https://colorado.rstudio.com/rsc>
pin_write(b, mtcars, "mtcars-01")
#> Guessing `type = 'rds'`
#> Writing to pin 'julia.silge/mtcars-01'
pin_write(b, mtcars, "julia.silge/mtcars-01")
#> Guessing `type = 'rds'`
#> Writing to pin 'julia.silge/mtcars-01'
pin_write(b, mtcars, "julia.silge/mtcars-02")
#> Guessing `type = 'rds'`
#> Writing to pin 'julia.silge/mtcars-02'
```

<sup>Created on 2022-08-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>