### PR TITLE
Add `R-CMD-check-hard`

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,57 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+name: R-CMD-check-hard
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-18.04,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/tests/testthat/test-board_rsconnect.R
+++ b/tests/testthat/test-board_rsconnect.R
@@ -1,3 +1,4 @@
+skip_if_not_installed("rsconnect")
 test_api_basic(board_rsconnect_test())
 test_api_versioning(board_rsconnect_test())
 test_api_meta(board_rsconnect_test())

--- a/tests/testthat/test-board_rsconnect_server.R
+++ b/tests/testthat/test-board_rsconnect_server.R
@@ -1,3 +1,5 @@
+skip_if_not_installed("mockery")
+
 test_that("auth allows manual, envvar and rsconnect values", {
   expect_equal(check_auth("manual"), "manual")
   expect_equal(check_auth("envvar"), "envvar")

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -1,4 +1,5 @@
 test_that("can round trip all types", {
+  skip_if_not_installed("qs")
   board <- board_temp()
 
   # Data frames

--- a/tests/testthat/test-pin.R
+++ b/tests/testthat/test-pin.R
@@ -17,6 +17,7 @@ test_that("can pin() a data frame", {
 })
 
 test_that("can pin() a data.table", {
+  skip_if_not_installed("data.table")
   board <- legacy_temp()
 
   dt <- data.table::data.table(x = 1:2, y = list("a", "b"))

--- a/vignettes/pins-update.Rmd
+++ b/vignettes/pins-update.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "Updating to pins 1.0.0"
+title: "Upgrading to pins 1.0.0"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{Upgrading to pins 1.0.0}

--- a/vignettes/rsc.Rmd
+++ b/vignettes/rsc.Rmd
@@ -10,7 +10,8 @@ vignette: >
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = requireNamespace("xml2", quietly = TRUE)
 )
 ```
 


### PR DESCRIPTION
We already have and probably will be adding more functionality that uses suggested dependencies (such as #644) so let's set ourselves up for success here.