### PR TITLE
Move arrow to suggests.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ BugReports: https://github.com/rstudio/pins-r/issues
 Depends: 
     R (>= 3.3.0)
 Imports:
-    arrow,
     cli,
     digest,
     ellipsis,
@@ -40,6 +39,7 @@ Imports:
     yaml,
     zip
 Suggests:
+    arrow,
     AzureStor,
     data.table,
     datasets,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pins (development version)
 
+* The `arrow` package is now suggested, rather than imported. (#644, @jonthegeek).
+
 # pins 1.0.2
 
 * `board_rsconnect()` now correctly finds the created date for pins (#623, 
@@ -107,7 +109,7 @@ This version includes the following modern boards:
   [paws](https://paws-r.github.io).
 
 * `board_url()` lets you create a manual board from a vector of URLs. This is 
-  useful because `pin_donwload()` and `pin_read()` are cached, so they only 
+  useful because `pin_download()` and `pin_read()` are cached, so they only 
   re-download the data if it has changed since the last time you used it (#409). 
   This board is a replacement for `pin()`'s ability to work directly with URLs
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pins (development version)
 
-* The `arrow` package is now suggested, rather than imported. (#644, @jonthegeek).
+* The `arrow` package is now suggested, rather than imported (#644, @jonthegeek).
 
 # pins 1.0.2
 

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -126,7 +126,7 @@ object_write <- function(x, path, type = "rds") {
   switch(type,
     rds = write_rds(x, path),
     json = jsonlite::write_json(x, path, auto_unbox = TRUE),
-    arrow = arrow::write_feather(x, path),
+    arrow = write_arrow(x, path),
     pickle = abort("'pickle' pins not supported in R"),
     csv = utils::write.csv(x, path, row.names = FALSE),
     qs = write_qs(x, path)
@@ -160,6 +160,12 @@ write_qs <- function(x, path) {
   invisible(path)
 }
 
+write_arrow <- function(x, path) {
+  check_installed("arrow")
+  arrow::write_feather(x, path)
+  invisible(path)
+}
+
 object_types <- c("rds", "json", "arrow", "pickle", "csv", "qs", "file")
 
 object_read <- function(meta) {
@@ -175,7 +181,7 @@ object_read <- function(meta) {
     switch(type,
       rds = readRDS(path),
       json = jsonlite::read_json(path, simplifyVector = TRUE),
-      arrow = arrow::read_feather(path),
+      arrow = read_arrow(path),
       pickle = abort("'pickle' pins not supported in R"),
       csv = utils::read.csv(path, stringsAsFactors = TRUE),
       qs = read_qs(path),
@@ -200,6 +206,11 @@ object_read <- function(meta) {
 read_qs <- function(path) {
   check_installed("qs")
   qs::qread(path, strict = TRUE)
+}
+
+read_arrow <- function(path) {
+  check_installed("arrow")
+  arrow::read_feather(path)
 }
 
 is_prefix <- function(prefix, string) {

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -1,5 +1,6 @@
 test_that("can round trip all types", {
   skip_if_not_installed("qs")
+  skip_if_not_installed("arrow")
   board <- board_temp()
 
   # Data frames


### PR DESCRIPTION
Closes #644.

Note: writing to arrow was previously returning the object (invisibly), rather than the fully qualified path (invisibly) like the help says. It now returns the path. As far as I can tell, no tests check this. I think json and csv likely return the object, but I haven't dug in to confirm.