### PR TITLE
Add a better error for `pin_versions()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pins (development version)
 
+* Improved error message for `pin_versions()` (#657).
+
 # pins 1.0.3
 
 * The `arrow` package is now suggested, rather than imported (#644, @jonthegeek).

--- a/R/pin_versions.R
+++ b/R/pin_versions.R
@@ -38,7 +38,9 @@ pin_versions <- function(board, name, ..., full = deprecated()) {
     lifecycle::deprecate_warn("1.0.0", "pin_versions(full)")
   }
 
-  if (missing(name) || is.board(name) || name %in% board_list()) {
+  if (missing(name) && is.board(board)) {
+    abort("Argument `name` is missing, with no default")
+  } else if (missing(name) || is.board(name) || name %in% board_list()) {
     swap <- board
     board <- if (missing(name)) NULL else name
     board <- board_get(board)

--- a/tests/testthat/_snaps/pin_versions.md
+++ b/tests/testthat/_snaps/pin_versions.md
@@ -5,13 +5,21 @@
       x <- pin_versions("x", "local")
       x <- pin_versions("x", board)
 
-# can't swap arguments with modern api
+# can't swap arguments and omit name with modern api
 
     Code
       pin_versions(name, board)
     Condition
       Error in `pin_versions()`:
       ! Please supply `board` then `name` when working with modern boards
+
+---
+
+    Code
+      pin_versions(board)
+    Condition
+      Error in `pin_versions()`:
+      ! Argument `name` is missing, with no default
 
 # `full` is deprecated
 

--- a/tests/testthat/_snaps/pin_versions.md
+++ b/tests/testthat/_snaps/pin_versions.md
@@ -5,7 +5,7 @@
       x <- pin_versions("x", "local")
       x <- pin_versions("x", board)
 
-# can't swap arguments and omit name with modern api
+# can't swap arguments or omit name with modern api
 
     Code
       pin_versions(name, board)

--- a/tests/testthat/test-pin_versions.R
+++ b/tests/testthat/test-pin_versions.R
@@ -10,10 +10,11 @@ test_that("can use old pin_versions() api", {
   })
 })
 
-test_that("can't swap arguments with modern api", {
+test_that("can't swap arguments or omit name with modern api", {
   board <- board_temp()
   name <- local_pin(board, 1)
   expect_snapshot(pin_versions(name, board), error = TRUE)
+  expect_snapshot(pin_versions(board), error = TRUE)
 })
 
 test_that("`full` is deprecated", {


### PR DESCRIPTION
Closes #656 

``` r
library(pins)
tmp <- tempdir()
board <- board_folder(tmp, versioned = TRUE)
pin_write(board, mtcars, 'my-beautiful-cars')
#> Guessing `type = 'rds'`
#> Creating new version '20220930T035916Z-66143'
#> Writing to pin 'my-beautiful-cars'
pin_versions(board)
#> Error in `pin_versions()`:
#> ! Argument `name` is missing, with no default

#> Backtrace:
#>     ▆
#>  1. └─pins::pin_versions(board)
#>  2.   └─rlang::abort("Argument `name` is missing, with no default") at pins-r/R/pin_versions.R:42:4
pin_versions(board, 'my-beautiful-cars')
#> # A tibble: 1 × 3
#>   version                created             hash 
#>   <chr>                  <dttm>              <chr>
#> 1 20220930T035916Z-66143 2022-09-29 21:59:16 66143
```

<sup>Created on 2022-09-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

We decided that we're not ready to deprecate or remove any of the code that keeps the v0 interface working, so for the time being, let's add more logic for this improved error.