### PR TITLE
Add test for writing with `board_folder()` ➡️ reading with `board_url()`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -32,39 +32,22 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
+      - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v1
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: rcmdcheck
 
-      - name: Check
-        env:
-          _R_CHECK_CRAN_INCOMING_: false
+      - name: "Set LOGNAME environment variables to get _R_CHECK_THINGS_IN_OTHER_DIRS_ to work"
         run: |
-          # Hack to get _R_CHECK_THINGS_IN_OTHER_DIRS_ to work
-          Sys.setenv("LOGNAME" = Sys.info()[["user"]])
-
-          options(crayon.enabled = TRUE)
-          rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "note", check_dir = "check")
+          cat("LOGNAME=", Sys.info()[["user"]], "\n", sep = "", file = Sys.getenv("GITHUB_ENV"), append = TRUE)
         shell: Rscript {0}
 
-      - name: Show testthat output
-        if: always()
-        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
-        shell: bash
-
-      - name: Upload check results
-        if: failure()
-        uses: actions/upload-artifact@main
+      - uses: r-lib/actions/check-r-package@v2
         with:
-          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
-          path: check
+          error-on: '"note"'
+          upload-snapshots: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 1.0.3.9000
 Authors@R: c(
     person("Julia", "Silge", , "julia.silge@rstudio.com", role = c("cre", "aut"),
            comment = c(ORCID = "0000-0002-3671-836X")),
-    person("Hadley", "Wickham", , "hadley@rstudio.com", role = c("aut"),
+    person("Hadley", "Wickham", , "hadley@rstudio.com", role = "aut",
            comment = c(ORCID = "0000-0003-4757-117X")),
     person("Javier", "Luraschi", , "jluraschi@gmail.com", role = "aut"),
     person(, "RStudio", role = c("cph", "fnd"))
@@ -56,6 +56,7 @@ Suggests:
     rsconnect,
     shiny,
     testthat (>= 3.0.0),
+    webfakes,
     xml2
 VignetteBuilder: 
     knitr

--- a/tests/testthat/test-board_url.R
+++ b/tests/testthat/test-board_url.R
@@ -53,6 +53,21 @@ test_that("raw pins can only be downloaded", {
     expect_equal("abcdefg")
 })
 
+test_that("can download pin from board_folder version dir", {
+  b1 <- board_folder(withr::local_tempfile())
+  b1 %>% pin_write(1:10, "x")
+  b2_path <- fs::path(b1$path, "x", pin_versions(b1, "x")$version)
+
+  b2_server <- webfakes::new_app()
+  b2_server$use(webfakes::mw_static(root = b2_path))
+  board_fake <- webfakes::new_app_process(b2_server)
+
+  b2 <- board_url(c(x = board_fake$url()))
+  b2 %>%
+    pin_read("x") %>%
+    expect_equal(1:10)
+})
+
 test_that("useful errors for unsupported methods", {
   board <- board_url(c("x" = "foo"))
 

--- a/tests/testthat/test-board_url.R
+++ b/tests/testthat/test-board_url.R
@@ -54,6 +54,8 @@ test_that("raw pins can only be downloaded", {
 })
 
 test_that("can download pin from board_folder version dir", {
+  skip_if_not_installed("webfakes")
+
   b1 <- board_folder(withr::local_tempfile())
   b1 %>% pin_write(1:10, "x")
   b2_path <- fs::path(b1$path, "x", pin_versions(b1, "x")$version)


### PR DESCRIPTION
Related to #650 

This particular test only checks putting the whole path including the version into the URL for `board_url()`, but let's get this piece reviewed and merged so we have a good strategy for testing this kind of process.