### PR TITLE
No more `stringsAsFactors`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,9 @@
 
 * Improved error message for `pin_versions()` (#657).
 
+* Changed `type = "csv"` to use R's default value for `stringsAsFactors` i.e. 
+  `FALSE` (#664).
+
 # pins 1.0.3
 
 * The `arrow` package is now suggested, rather than imported (#644, @jonthegeek).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,16 @@
 # pins (development version)
 
+## Breaking changes
+
+* Changed `type = "csv"` to use R's default value for `stringsAsFactors` i.e. 
+  `FALSE` (#664).
+  
+## Other improvements
+
 * Added vignette describing how to manage custom formats (#631, @ijlyttle).
 
 * Improved error message for `pin_versions()` (#657).
 
-* Changed `type = "csv"` to use R's default value for `stringsAsFactors` i.e. 
-  `FALSE` (#664).
 
 # pins 1.0.3
 

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -183,7 +183,8 @@ object_read <- function(meta) {
       json = jsonlite::read_json(path, simplifyVector = TRUE),
       arrow = read_arrow(path),
       pickle = abort("'pickle' pins not supported in R"),
-      csv = utils::read.csv(path, stringsAsFactors = TRUE),
+      joblib = abort("'joblib' pins not supported in R"),
+      csv = utils::read.csv(path),
       qs = read_qs(path),
       file = abort(c(
         "Pin does not declare file type so can't be automatically read",

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -128,6 +128,7 @@ object_write <- function(x, path, type = "rds") {
     json = jsonlite::write_json(x, path, auto_unbox = TRUE),
     arrow = write_arrow(x, path),
     pickle = abort("'pickle' pins not supported in R"),
+    joblib = abort("'joblib' pins not supported in R"),
     csv = utils::write.csv(x, path, row.names = FALSE),
     qs = write_qs(x, path)
   )


### PR DESCRIPTION
Closes #626 

Setting `stringsAsFactors = TRUE` seems quite unexpected now, especially 2+ years after this default changed in base R. It results in behavior that surprises many (I would guess most) users, for example see #596.