### PR TITLE
Add docs for automatic dependency discovery

### DIFF
--- a/R/board_azure.R
+++ b/R/board_azure.R
@@ -19,6 +19,13 @@
 #' for working with blobs that is much faster when working with directories.
 #' You should consider using this rather than the classic blob API where
 #' possible; see the examples below.
+#'
+#' `board_azure()` is powered by the AzureStor package, which is a suggested
+#' dependency of pins (not required for pins in general). If you run into errors
+#' when deploying content to a server like <https://shinyapps.io> or
+#' [Connect](https://posit.co/products/enterprise/connect/), add
+#' `library(AzureStor)` to your app or document for [automatic dependency
+#' discovery](https://support.posit.co/hc/en-us/articles/229998627-Why-does-my-app-work-locally-but-not-on-my-RStudio-Connect-server).
 #' @export
 #' @examples
 #' if (requireNamespace("AzureStor")) {

--- a/R/board_ms365.R
+++ b/R/board_ms365.R
@@ -15,9 +15,27 @@
 #'   due to document protection policies that prohibit deleting non-empty
 #'   folders.
 #' @details
-#' Sharing a board in OneDrive (personal or business) is a bit complicated, as OneDrive normally allows only the person who owns the drive to access files and folders. First, the drive owner has to set the board folder as shared with other users, using either the OneDrive web interface or Microsoft365R's `ms_drive_item$create_share_link()` method. The other users then call `board_ms365` with a _drive item object_ in the `path` argument, pointing to the shared folder. See the examples below.
+#' Sharing a board in OneDrive (personal or business) is a bit complicated, as
+#' OneDrive normally allows only the person who owns the drive to access files
+#' and folders. First, the drive owner has to set the board folder as shared
+#' with other users, using either the OneDrive web interface or Microsoft365R's
+#' `ms_drive_item$create_share_link()` method. The other users then call
+#' `board_ms365` with a _drive item object_ in the `path` argument, pointing to
+#' the shared folder. See the examples below.
 #'
-#' Sharing a board in SharePoint Online is much more straightforward, assuming all users have access to the document library: in this case, everyone can use the same call `board_ms365(doclib, "path/to/board")`. If you want to share a board with users outside your team, follow the same steps for sharing a board in OneDrive.
+#' Sharing a board in SharePoint Online is much more straightforward, assuming
+#' all users have access to the document library: in this case, everyone can
+#' use the same call `board_ms365(doclib, "path/to/board")`. If you want to
+#' share a board with users outside your team, follow the same steps for sharing
+#' a board in OneDrive.
+#'
+#' `board_ms365()` is powered by the Microsoft365R package, which is a suggested
+#' dependency of pins (not required for pins in general). If you run into errors
+#' when deploying content to a server like <https://shinyapps.io> or
+#' [Connect](https://posit.co/products/enterprise/connect/), add
+#' `library(Microsoft365R)` to your app or document for [automatic dependency
+#' discovery](https://support.posit.co/hc/en-us/articles/229998627-Why-does-my-app-work-locally-but-not-on-my-RStudio-Connect-server).
+#'
 #' @export
 #' @examples
 #' \dontrun{

--- a/R/board_s3.R
+++ b/R/board_s3.R
@@ -47,6 +47,12 @@
 #'   return useful output.
 #' * You can pass arguments for [paws.storage::s3_put_object] such as `Tagging`
 #'   and `ServerSideEncryption` through the dots of `pin_write()`.
+#' * `board_s3()` is powered by the paws.storage package, which is a
+#'   suggested dependency of pins (not required for pins in general). If
+#'   you run into errors when deploying content to a server like
+#'   <https://shinyapps.io> or [Connect](https://posit.co/products/enterprise/connect/),
+#'   add `library(paws.storage)` to your app or document for [automatic
+#'   dependency discovery](https://support.posit.co/hc/en-us/articles/229998627-Why-does-my-app-work-locally-but-not-on-my-RStudio-Connect-server).
 #'
 #' @inheritParams new_board
 #' @param bucket Bucket name. You can only write to an existing bucket.

--- a/man/board_azure.Rd
+++ b/man/board_azure.Rd
@@ -41,6 +41,12 @@ but is relatively old and inefficient. ADLSgen2 is a modern replacement API
 for working with blobs that is much faster when working with directories.
 You should consider using this rather than the classic blob API where
 possible; see the examples below.
+
+\code{board_azure()} is powered by the AzureStor package, which is a suggested
+dependency of pins (not required for pins in general). If you run into errors
+when deploying content to a server like \url{https://shinyapps.io} or
+\href{https://posit.co/products/enterprise/connect/}{Connect}, add
+\code{library(AzureStor)} to your app or document for \href{https://support.posit.co/hc/en-us/articles/229998627-Why-does-my-app-work-locally-but-not-on-my-RStudio-Connect-server}{automatic dependency discovery}.
 }
 \examples{
 if (requireNamespace("AzureStor")) {

--- a/man/board_ms365.Rd
+++ b/man/board_ms365.Rd
@@ -37,9 +37,25 @@ Pin data to a folder in Onedrive or a SharePoint Online document library
 using the Microsoft365R package.
 }
 \details{
-Sharing a board in OneDrive (personal or business) is a bit complicated, as OneDrive normally allows only the person who owns the drive to access files and folders. First, the drive owner has to set the board folder as shared with other users, using either the OneDrive web interface or Microsoft365R's \code{ms_drive_item$create_share_link()} method. The other users then call \code{board_ms365} with a \emph{drive item object} in the \code{path} argument, pointing to the shared folder. See the examples below.
+Sharing a board in OneDrive (personal or business) is a bit complicated, as
+OneDrive normally allows only the person who owns the drive to access files
+and folders. First, the drive owner has to set the board folder as shared
+with other users, using either the OneDrive web interface or Microsoft365R's
+\code{ms_drive_item$create_share_link()} method. The other users then call
+\code{board_ms365} with a \emph{drive item object} in the \code{path} argument, pointing to
+the shared folder. See the examples below.
 
-Sharing a board in SharePoint Online is much more straightforward, assuming all users have access to the document library: in this case, everyone can use the same call \code{board_ms365(doclib, "path/to/board")}. If you want to share a board with users outside your team, follow the same steps for sharing a board in OneDrive.
+Sharing a board in SharePoint Online is much more straightforward, assuming
+all users have access to the document library: in this case, everyone can
+use the same call \code{board_ms365(doclib, "path/to/board")}. If you want to
+share a board with users outside your team, follow the same steps for sharing
+a board in OneDrive.
+
+\code{board_ms365()} is powered by the Microsoft365R package, which is a suggested
+dependency of pins (not required for pins in general). If you run into errors
+when deploying content to a server like \url{https://shinyapps.io} or
+\href{https://posit.co/products/enterprise/connect/}{Connect}, add
+\code{library(Microsoft365R)} to your app or document for \href{https://support.posit.co/hc/en-us/articles/229998627-Why-does-my-app-work-locally-but-not-on-my-RStudio-Connect-server}{automatic dependency discovery}.
 }
 \examples{
 \dontrun{

--- a/man/board_s3.Rd
+++ b/man/board_s3.Rd
@@ -88,6 +88,11 @@ a new bucket from R with \link[paws.storage:s3_create_bucket]{paws}.
 return useful output.
 \item You can pass arguments for \link[paws.storage:s3_put_object]{paws.storage::s3_put_object} such as \code{Tagging}
 and \code{ServerSideEncryption} through the dots of \code{pin_write()}.
+\item \code{board_s3()} is powered by the paws.storage package, which is a
+suggested dependency of pins (not required for pins in general). If
+you run into errors when deploying content to a server like
+\url{https://shinyapps.io} or \href{https://posit.co/products/enterprise/connect/}{Connect},
+add \code{library(paws.storage)} to your app or document for \href{https://support.posit.co/hc/en-us/articles/229998627-Why-does-my-app-work-locally-but-not-on-my-RStudio-Connect-server}{automatic dependency discovery}.
 }
 }
 


### PR DESCRIPTION
Related to #673 

I did not add this to `board_rsconnect()` because the needed packages are always there.

I looked into how to do this with less repetition via `@includeRmd` or other templating, but you have to have the board to call `required_pkgs()` and we don't have all the boards when building the docs or on CRAN.