### PR TITLE
Update Connect preview

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,8 @@
   
 * Updated `board_url()` to handle versions recorded via a manifest file 
   (#681, based on work of @ijlyttle).
+  
+* Updated code preview on Posit Connect (#690).
 
 
 # pins 1.0.3

--- a/R/board_rsconnect.R
+++ b/R/board_rsconnect.R
@@ -334,7 +334,7 @@ pin_search.pins_board_rsconnect <- function(board, search = NULL, ...) {
 #' @rdname board_deparse
 #' @export
 board_deparse.pins_board_rsconnect <- function(board, ...) {
-  expr(board_rsconnect("envvar", server = !!board$url))
+  expr(board_rsconnect(auth = "envvar"))
 }
 
 #' @rdname required_pkgs.pins_board

--- a/inst/preview/index.html
+++ b/inst/preview/index.html
@@ -47,7 +47,7 @@
      </section>
 
     <section>
-    <h3>Code</h3>
+    <h3>R Code</h3>
       <pre id="pin-r" class="pin-code"><code class="r">library(pins)
 board <- {{{board_deparse}}}
 pin_read(board, "{{pin_name}}")</code></pre>

--- a/tests/testthat/_snaps/board_rsconnect.md
+++ b/tests/testthat/_snaps/board_rsconnect.md
@@ -5,12 +5,20 @@
     Output
       [1] "rsconnect"
 
+# metadata checking functions give correct errors
+
+    `tags` must be a character vector.
+
+---
+
+    `metadata` must be a list.
+
 # can deparse
 
     Code
       board_deparse(board)
     Output
-      board_rsconnect("envvar", server = "https://colorado.rstudio.com/rsc")
+      board_rsconnect(auth = "envvar")
 
 # can find content by full/partial name
 

--- a/tests/testthat/_snaps/board_rsconnect_bundle.md
+++ b/tests/testthat/_snaps/board_rsconnect_bundle.md
@@ -57,9 +57,9 @@
          </section>
     
         <section>
-        <h3>Code</h3>
+        <h3>R Code</h3>
           <pre id="pin-r" class="pin-code"><code class="r">library(pins)
-    board <- board_rsconnect("envvar", server = "http://example.com")
+    board <- board_rsconnect(auth = "envvar")
     pin_read(board, "TEST/test")</code></pre>
         <script type="text/javascript">
           hljs.registerLanguage("r", highlight_r);


### PR DESCRIPTION
Closes #615 

For now, let's not try to show code for both R and Python for each pin; that would require us at the least to check the type of pin to see if it is readable. This PR:

- updates the preview so it says "R Code" ([see an example](https://colorado.posit.co/rsc/content/760d199d-50da-4c7b-ac45-c829263112f1/))
- updates the `deparse` method so it follows the [current Connect docs](https://docs.posit.co/connect/user/pins/)