### PR TITLE
Refactor `print` method for boards

### DIFF
--- a/R/board.R
+++ b/R/board.R
@@ -56,37 +56,21 @@ new_board_v1 <- function(board, cache, versioned = FALSE, ...) {
 
 
 #' @export
-print.pins_board <- function(x, ...) {
-  cat(paste0(cli::style_bold("Pin board"), " <", class(x)[[1]], ">\n"))
-
+format.pins_board <- function(x, ...) {
+  first_class <- class(x)[[1]]
   desc <- board_desc(x)
-  if (length(desc) > 0) {
-    cat(paste0(desc, "\n", collapse = ""))
-  }
-  cat("Cache size: ", format(cache_size(x)), "\n", sep = "")
-
-  if (1 %in% x$api) {
-    pins <- pin_list(x)
-  } else {
-    pins <- pin_find(board = x)$name
-  }
-
-  # Some boards (e.g. kaggle_competitions have an infeasibly large number
-  # and there's no point in listing them all)
-  if (!identical(pins, NA)) {
-    n <- length(pins)
-    if (n > 0) {
-      if (n > 20) {
-        pins <- c(pins[1:19], "...")
-      }
-      contents <- paste0(
-        "Pins [", n, "]: ",
-        paste0("'", pins, "'", collapse = ", ")
-      )
-      cat(strwrap(contents, exdent = 2), sep = "\n")
+  cli::cli_format_method({
+    cli::cli_text("Pin board {.cls {first_class}}")
+    if (length(desc) > 0) {
+      cli::cli_text("{desc}")
     }
-  }
+    cli::cli_text("Cache size: {format(cache_size(x))}")
+  })
+}
 
+#' @export
+print.pins_board <- function(x, ...) {
+  cat(format(x), sep = "\n")
   invisible(x)
 }
 

--- a/R/board_folder.R
+++ b/R/board_folder.R
@@ -33,7 +33,7 @@ board_folder <- function(path, versioned = FALSE) {
 }
 #' @export
 board_desc.pins_board_folder <- function(board, ...) {
-  paste0("Path: '", board$path, "'")
+  glue("Path: '{board$path}'")
 }
 
 #' @export

--- a/tests/testthat/test-board_folder.R
+++ b/tests/testthat/test-board_folder.R
@@ -5,6 +5,7 @@ test_api_manifest(board_temp())
 
 test_that("has useful print method", {
   path <- withr::local_tempfile()
+  withr::local_options(cli.width = 120)
   expect_snapshot(
     board_folder(path),
     transform = ~ gsub("Path: .*", "Path: '<redacted>'", .x)


### PR DESCRIPTION
Closes #714 

This PR removes calling `pin_list()` when you print out a board (too slow) and refactors the `print` method to take advantage of [cli](https://cli.r-lib.org/) functions.