### PR TITLE
Add test for writing to another user's pin

### DIFF
--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -763,17 +763,17 @@ read_creds <- function() {
   }
   readRDS(path)
 }
-add_another_user <- function(board, user_name, guid) {
+add_another_user <- function(board, user_name, content_id) {
 
-  ## get GUID for user_name
+  ## get user GUID for new owner from user_name
   path <- glue("v1/users/")
   path <- rsc_path(board, path)
   auth <- rsc_auth(board, path, "GET")
   query <- glue("prefix={user_name}")
-  resp <- httr::GET(board$url, path = path, auth)
+  resp <- httr::GET(board$url, path = path, query = query, auth)
   httr::stop_for_status(resp)
   res <- httr::content(resp)
-  principal_guid <- map_chr(res$results, "guid")
+  principal_guid <- purrr::pluck(res$results[[1]], "guid")
 
   ## add user_name as owner for content at GUID
   body <- glue('{{
@@ -782,7 +782,7 @@ add_another_user <- function(board, user_name, guid) {
   "role": "owner"
   }}')
 
-  path <- glue("v1/content/{guid}/permissions")
+  path <- glue("v1/content/{content_id}/permissions")
   path <- rsc_path(board, path)
   auth <- rsc_auth(board, path, "POST")
   resp <- httr::POST(board$url, path = path, body = body, auth)

--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -773,7 +773,7 @@ add_another_user <- function(board, user_name, content_id) {
   resp <- httr::GET(board$url, path = path, query = query, auth)
   httr::stop_for_status(resp)
   res <- httr::content(resp)
-  principal_guid <- purrr::pluck(res$results[[1]], "guid")
+  principal_guid <- res$results[[1]]$guid
 
   ## add user_name as owner for content at GUID
   body <- glue('{{

--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -730,13 +730,7 @@ board_connect_test <- function(...) {
 # Use Colorado for local testing
 connect_has_colorado <- function() {
   accounts <- rsconnect::accounts()
-  any(c("colorado.rstudio.com", "colorado.posit.co") %in% accounts$server)
-}
-board_connect_colorado <- function(...) {
-  if (!connect_has_colorado()) {
-    testthat::skip("board_connect_colorado() only works with Posit's demo server")
-  }
-  board_connect(..., server = "colorado.posit.co", auth = "rsconnect", cache = fs::file_temp())
+  "colorado.posit.co" %in% accounts$server
 }
 
 board_connect_colorado <- function(...) {

--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -763,4 +763,29 @@ read_creds <- function() {
   }
   readRDS(path)
 }
+add_another_user <- function(board, user_name, guid) {
 
+  ## get GUID for user_name
+  path <- glue("v1/users/")
+  path <- rsc_path(board, path)
+  auth <- rsc_auth(board, path, "GET")
+  query <- glue("prefix={user_name}")
+  resp <- httr::GET(board$url, path = path, auth)
+  httr::stop_for_status(resp)
+  res <- content(resp)
+  principal_guid <- map_chr(res$results, "guid")
+
+  ## add user_name as owner for content at GUID
+  body <- glue('{{
+  "principal_guid": "{principal_guid}",
+  "principal_type": "user",
+  "role": "owner"
+  }}')
+
+  path <- glue("v1/content/{guid}/permissions")
+  path <- rsc_path(board, path)
+  auth <- rsc_auth(board, path, "POST")
+  resp <- httr::POST(board$url, path = path, body = body, auth)
+  httr::stop_for_status(resp)
+  invisible(resp)
+}

--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -772,7 +772,7 @@ add_another_user <- function(board, user_name, guid) {
   query <- glue("prefix={user_name}")
   resp <- httr::GET(board$url, path = path, auth)
   httr::stop_for_status(resp)
-  res <- content(resp)
+  res <- httr::content(resp)
   principal_guid <- map_chr(res$results, "guid")
 
   ## add user_name as owner for content at GUID

--- a/tests/testthat/test-board_connect.R
+++ b/tests/testthat/test-board_connect.R
@@ -54,6 +54,18 @@ test_that("can update access_type", {
   expect_equal(rsc_content_info(board, guid)$access_type, "logged_in")
 })
 
+test_that("can write pin created another user", {
+  board1 <- board_connect_susan()
+  name <- local_pin(board1, 1:5)
+  guid <- pin_meta(board1, name)$local$content_id
+  add_another_user(board1, "derek", guid)
+
+  board2 <- board_connect_derek()
+  pin_write(board2, 10:15, name)
+
+  expect_equal(pin_read(board1, name), 10:15)
+})
+
 test_that("can deparse", {
   board <- new_board_v1(
     "pins_board_connect",


### PR DESCRIPTION
Closes #680 

This PR adds a new test that we can:

- Write a pin as one Connect user
- Add a different Connect user as owner (new little testing function to do this)
- New owner can write to the pin