### PR TITLE
Add `type = "parquet"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `board_s3()` now uses pagination for listing and versioning (#719, @mzorko).
 
+* Added `type = "parquet"` to read and write Parquet files (#729).
+
 # pins 1.1.0
 
 ## Breaking changes

--- a/README.Rmd
+++ b/README.Rmd
@@ -70,7 +70,7 @@ It takes three arguments: the board to pin to, an object, and a name:
 board %>% pin_write(head(mtcars), "mtcars")
 ```
 
-As you can see, the data saved as an `.rds` by default, but depending on what you're saving and who else you want to read it, you might use the `type` argument to instead save it as a `csv`, `json`, or `arrow` file.
+As you can see, the data saved as an `.rds` by default, but depending on what you're saving and who else you want to read it, you might use the `type` argument to instead save it as a Parquet, Arrow, CSV, or JSON file.
 
 You can later retrieve the pinned data with `pin_read()`:
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ board <- board_temp()
 board
 #> Pin board <pins_board_folder>
 #> Path:
-#> '/var/folders/hv/hzsmmyk9393_m7q3nscx1slc0000gn/T/RtmpTxyyP1/pins-114c073a9ddd2'
+#> '/var/folders/hv/hzsmmyk9393_m7q3nscx1slc0000gn/T/RtmpwGre3p/pins-15a8b4f3f602c'
 #> Cache size: 0
 ```
 
@@ -71,13 +71,14 @@ arguments: the board to pin to, an object, and a name:
 ``` r
 board %>% pin_write(head(mtcars), "mtcars")
 #> Guessing `type = 'rds'`
-#> Creating new version '20230223T220424Z-a800d'
+#> Creating new version '20230303T233508Z-a800d'
 #> Writing to pin 'mtcars'
 ```
 
 As you can see, the data saved as an `.rds` by default, but depending on
 what you’re saving and who else you want to read it, you might use the
-`type` argument to instead save it as a `csv`, `json`, or `arrow` file.
+`type` argument to instead save it as a Parquet, Arrow, CSV, or JSON
+file.
 
 You can later retrieve the pinned data with `pin_read()`:
 

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -38,9 +38,9 @@ you expect. You can find the hash of an existing pin by looking for
 \item{x}{An object (typically a data frame) to pin.}
 
 \item{type}{File type used to save \code{x} to disk. Must be one of
-"csv", "json", "rds", "arrow", or "qs". If not supplied, will use JSON for
-bare lists and RDS for everything else. Be aware that CSV and JSON are
-plain text formats, while RDS, Arrow, and
+"csv", "json", "rds", "parquet", "arrow", or "qs". If not supplied, will
+use JSON for bare lists and RDS for everything else. Be aware that CSV and
+JSON are plain text formats, while RDS, Parquet, Arrow, and
 \href{https://CRAN.R-project.org/package=qs}{qs} are binary formats.}
 
 \item{title}{A title for the pin; most important for shared boards so that

--- a/tests/testthat/_snaps/pin-read-write.md
+++ b/tests/testthat/_snaps/pin-read-write.md
@@ -23,7 +23,7 @@
       pin_write(board, mtcars, name = "mtcars", type = "froopy-loops")
     Condition
       Error in `object_write()`:
-      ! `type` must be one of "rds", "json", "arrow", "pickle", "csv", or "qs", not "froopy-loops".
+      ! `type` must be one of "rds", "json", "parquet", "arrow", "pickle", "csv", or "qs", not "froopy-loops".
     Code
       pin_write(board, mtcars, name = "mtcars", metadata = 1)
     Condition

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -8,13 +8,16 @@ test_that("can round trip all types", {
   pin_write(board, df, "df-1", type = "rds")
   expect_equal(pin_read(board, "df-1"), df)
 
-  pin_write(board, df, "df-2", type = "arrow")
+  pin_write(board, df, "df-2", type = "parquet")
   expect_equal(pin_read(board, "df-2"), df)
 
-  pin_write(board, df, "df-3", type = "csv")
+  pin_write(board, df, "df-3", type = "arrow")
+  expect_equal(pin_read(board, "df-2"), df)
+
+  pin_write(board, df, "df-4", type = "csv")
   expect_equal(pin_read(board, "df-3"), df)
 
-  pin_write(board, df, "df-4", type = "qs")
+  pin_write(board, df, "df-5", type = "qs")
   expect_equal(pin_read(board, "df-4"), df)
 
   # List

--- a/vignettes/pins.Rmd
+++ b/vignettes/pins.Rmd
@@ -61,11 +61,11 @@ The only rule for a pin name is that it can't contain slashes.
 As you can see from the output, pins has chosen to save this data to an `.rds` file.
 But you can choose another option depending on your goals:
 
--   `type = "rds"` uses `writeRDS()` to create a binary R data file. It can save any R object but it's only readable from R, not other languages.
--   `type = "csv"` uses `write.csv()` to create a `.csv` file. CSVs can read by any application, but only support simple columns (e.g. numbers, strings, dates), can take up a lot of disk space, and can be slow to read.
--   `type = "parquet"` uses `arrow::write_parquet()` to create a Parquet file. [Parquet](https://parquet.apache.org/) is a modern, language-independent, column-oriented file format for efficient data storage and retrieval. 
--   `type = "arrow"` uses `arrow::write_feather()` to create an Arrow/Feather file. Read the [FAQs from the Arrow project](https://arrow.apache.org/faq/) for more on the differences between Arrow and Parquet as file formats.
--   `type = "json"` uses `jsonlite::write_json()` to create a `.json` file. Pretty much every programming language can read json files, but they only work well for nested lists.
+-   `type = "rds"` uses `writeRDS()` to create a binary R data file. It can save any R object (including trained models) but it's only readable from R, not other languages.
+-   `type = "csv"` uses `write.csv()` to create a CSV file. CSVs are plain text and can be read easily by many applications, but they only support simple columns (e.g. numbers, strings), can take up a lot of disk space, and can be slow to read.
+-   `type = "parquet"` uses `arrow::write_parquet()` to create a Parquet file. [Parquet](https://parquet.apache.org/) is a modern, language-independent, column-oriented file format for efficient data storage and retrieval. Parquet is an excellent choice for storing tabular data but requires the [arrow](https://arrow.apache.org/docs/r/) package.
+-   `type = "arrow"` uses `arrow::write_feather()` to create an Arrow/Feather file.
+-   `type = "json"` uses `jsonlite::write_json()` to create a JSON file. Pretty much every programming language can read json files, but they only work well for nested lists.
 -   `type = "qs"` uses `qs::qsave()` to create a binary R data file, like `writeRDS()`. This format achieves faster read/write speeds than RDS, and compresses data more efficiently, making it a good choice for larger objects. Read more on the [qs package](https://github.com/traversc/qs).
 
 After you've pinned an object, you can read it back with `pin_read()`:

--- a/vignettes/pins.Rmd
+++ b/vignettes/pins.Rmd
@@ -63,7 +63,7 @@ But you can choose another option depending on your goals:
 
 -   `type = "rds"` uses `writeRDS()` to create a binary R data file. It can save any R object but it's only readable from R, not other languages.
 -   `type = "csv"` uses `write.csv()` to create a `.csv` file. CSVs can read by any application, but only support simple columns (e.g. numbers, strings, dates), can take up a lot of disk space, and can be slow to read.
--   `type = "parquet"` uses `arrow::write_parquet()` to create a Parquet file. [Parquet](https://parquet.apache.org/) is a modern, language-independent, column-oriented file format for efficient data storage and retrieval. Parquet is a storage format used with [Arrow](https://arrow.apache.org), an in-memory columnar format.
+-   `type = "parquet"` uses `arrow::write_parquet()` to create a Parquet file. [Parquet](https://parquet.apache.org/) is a modern, language-independent, column-oriented file format for efficient data storage and retrieval. 
 -   `type = "arrow"` uses `arrow::write_feather()` to create an Arrow/Feather file. Read the [FAQs from the Arrow project](https://arrow.apache.org/faq/) for more on the differences between Arrow and Parquet as file formats.
 -   `type = "json"` uses `jsonlite::write_json()` to create a `.json` file. Pretty much every programming language can read json files, but they only work well for nested lists.
 -   `type = "qs"` uses `qs::qsave()` to create a binary R data file, like `writeRDS()`. This format achieves faster read/write speeds than RDS, and compresses data more efficiently, making it a good choice for larger objects. Read more on the [qs package](https://github.com/traversc/qs).

--- a/vignettes/pins.Rmd
+++ b/vignettes/pins.Rmd
@@ -63,7 +63,8 @@ But you can choose another option depending on your goals:
 
 -   `type = "rds"` uses `writeRDS()` to create a binary R data file. It can save any R object but it's only readable from R, not other languages.
 -   `type = "csv"` uses `write.csv()` to create a `.csv` file. CSVs can read by any application, but only support simple columns (e.g. numbers, strings, dates), can take up a lot of disk space, and can be slow to read.
--   `type = "arrow"` uses `arrow::write_feather()` to create an arrow/feather file. [Arrow](https://arrow.apache.org) is a modern, language-independent, high-performance file format designed for data science. Not every tool can read arrow files, but support is growing rapidly.
+-   `type = "parquet"` uses `arrow::write_parquet()` to create a Parquet file. [Parquet](https://parquet.apache.org/) is a modern, language-independent, column-oriented file format for efficient data storage and retrieval. Parquet is a storage format used with [Arrow](https://arrow.apache.org), an in-memory columnar format.
+-   `type = "arrow"` uses `arrow::write_feather()` to create an Arrow/Feather file. Read the [FAQs from the Arrow project](https://arrow.apache.org/faq/) for more on the differences between Arrow and Parquet as file formats.
 -   `type = "json"` uses `jsonlite::write_json()` to create a `.json` file. Pretty much every programming language can read json files, but they only work well for nested lists.
 -   `type = "qs"` uses `qs::qsave()` to create a binary R data file, like `writeRDS()`. This format achieves faster read/write speeds than RDS, and compresses data more efficiently, making it a good choice for larger objects. Read more on the [qs package](https://github.com/traversc/qs).
 


### PR DESCRIPTION
Closes #713 

``` r
library(pins)
b <- board_temp()
b %>% pin_write(palmerpenguins::penguins, "penguins-have-factors", type = "parquet")
#> Creating new version '20230306T164332Z-cdfce'
#> Writing to pin 'penguins-have-factors'
b %>% pin_read("penguins-have-factors")
#> # A tibble: 344 × 8
#>    species island    bill_length_mm bill_depth_mm flipper_…¹ body_…² sex    year
#>    <fct>   <fct>              <dbl>         <dbl>      <int>   <int> <fct> <int>
#>  1 Adelie  Torgersen           39.1          18.7        181    3750 male   2007
#>  2 Adelie  Torgersen           39.5          17.4        186    3800 fema…  2007
#>  3 Adelie  Torgersen           40.3          18          195    3250 fema…  2007
#>  4 Adelie  Torgersen           NA            NA           NA      NA <NA>   2007
#>  5 Adelie  Torgersen           36.7          19.3        193    3450 fema…  2007
#>  6 Adelie  Torgersen           39.3          20.6        190    3650 male   2007
#>  7 Adelie  Torgersen           38.9          17.8        181    3625 fema…  2007
#>  8 Adelie  Torgersen           39.2          19.6        195    4675 male   2007
#>  9 Adelie  Torgersen           34.1          18.1        193    3475 <NA>   2007
#> 10 Adelie  Torgersen           42            20.2        190    4250 <NA>   2007
#> # … with 334 more rows, and abbreviated variable names ¹​flipper_length_mm,
#> #   ²​body_mass_g
```

<sup>Created on 2023-03-06 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Notice we get all the original types back.

