### PR TITLE
New `force_identical_write` arg

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 * Fixed bug in `cache_prune()` to correctly find caches for `board_url()` (#734).
 
-* Added new `check_hash` argument when writing a pin to check whether the pin 
+* `pin_write()` gains a `check_hash` argument to check whether the pin 
   contents are identical to the last version (#735).
 
 # pins 1.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 
 * Fixed bug in `cache_prune()` to correctly find caches for `board_url()` (#734).
 
-* `pin_write()` gains a `check_hash` argument to check whether the pin 
+* `pin_write()` gains a `compare_hash` argument to check whether the pin 
   contents are identical to the last version (#735).
 
 # pins 1.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # pins (development version)
 
+## Breaking changes
+
+* `pin_write()` no longer writes identical pin contents by default, and gains a
+  `force_identical_write` argument for writing even when the pin contents are 
+  identical to the last version (#735).
+
+## Other improvements
+
 * The `print` method for boards no longer calls `pin_list()` internally (#718).
 
 * `board_s3()` now uses pagination for listing and versioning (#719, @mzorko).
@@ -15,9 +23,6 @@
   well as new board for Connect vanity URLs `board_connect_url()` (#732).  
 
 * Fixed bug in `cache_prune()` to correctly find caches for `board_url()` (#734).
-
-* `pin_write()` gains a `compare_hash` argument to check whether the pin 
-  contents are identical to the last version (#735).
 
 # pins 1.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,9 @@
 
 * Fixed bug in `cache_prune()` to correctly find caches for `board_url()` (#734).
 
+* Added new `check_hash` argument when writing a pin to check whether the pin 
+  contents are identical to the last version (#735).
+
 # pins 1.1.0
 
 ## Breaking changes

--- a/R/pin-meta.R
+++ b/R/pin-meta.R
@@ -46,6 +46,8 @@ pin_meta <- function(board, name, version = NULL, ...) {
   UseMethod("pin_meta")
 }
 
+possibly_pin_meta <- possibly(pin_meta)
+
 multi_meta <- function(board, names) {
   meta <- map(names, possibly(pin_meta, empty_local_meta), board = board)
 

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -119,9 +119,10 @@ pin_write <- function(board, x,
   if (check_hash) {
     old_hash <- possibly_pin_meta(board, name)$pin_hash
     if (!is.null(old_hash) && old_hash == meta$pin_hash) {
-      cli::cli_warn(
-        "The hash of pin {.val {name}} has not changed and will not be stored."
-      )
+      cli::cli_warn(c(
+        "!" = "The hash of pin {.val {name}} has not changed.",
+        "*" = "Your pin will not be stored."
+      ))
       return(invisible(name))
     }
   }

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -65,8 +65,8 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #' @param tags A character vector of tags for the pin; most important for
 #'   discoverability on shared boards.
 #' @param check_hash Check whether the pin contents are identical to the last
-#'   version (using a hash), and then **do not store** the pin again. Defaults
-#'   to `FALSE`.
+#'   version if one exists (using the hash), and then **do not store** the pin
+#'   again. Defaults to `FALSE`.
 #' @rdname pin_read
 #' @export
 pin_write <- function(board, x,
@@ -116,8 +116,7 @@ pin_write <- function(board, x,
   meta$user <- metadata
 
   if (check_hash) {
-    old_hash <- possibly_pin_meta(board, name)
-    old_hash <- old_hash$pin_hash
+    old_hash <- possibly_pin_meta(board, name)$pin_hash
     if (!is.null(old_hash) && old_hash == meta$pin_hash) {
       cli::cli_warn(
         "The hash of pin {.val {name}} has not changed and will not be stored."

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -66,7 +66,8 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #'   discoverability on shared boards.
 #' @param check_hash Check whether the pin contents are identical to the last
 #'   version if one exists (using the hash), and then **do not store** the pin
-#'   again. Defaults to `FALSE`.
+#'   again. This argument does not check the pin metadata, only the pin
+#'   contents. Defaults to `FALSE`.
 #' @rdname pin_read
 #' @export
 pin_write <- function(board, x,

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -64,10 +64,9 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #'   use the default for `board`
 #' @param tags A character vector of tags for the pin; most important for
 #'   discoverability on shared boards.
-#' @param compare_hash Compare the pin contents to the last version if one
-#'   exists (using the hash), and if identical, **do not store** the pin again.
-#'   This argument does not compare any pin metadata, only the pin contents.
-#'   Defaults to `TRUE`.
+#' @param force_identical_write Store the pin even if the pin contents are
+#'   identical to the last version (compared using the hash). Only the pin
+#'   contents are compared, not the pin metadata. Defaults to `FALSE`.
 #' @rdname pin_read
 #' @export
 pin_write <- function(board, x,
@@ -79,7 +78,7 @@ pin_write <- function(board, x,
                       versioned = NULL,
                       tags = NULL,
                       ...,
-                      compare_hash = TRUE) {
+                      force_identical_write = FALSE) {
   ellipsis::check_dots_used()
   check_board(board, "pin_write", "pin")
 
@@ -116,7 +115,7 @@ pin_write <- function(board, x,
   )
   meta$user <- metadata
 
-  if (compare_hash) {
+  if (!force_identical_write) {
     old_hash <- possibly_pin_meta(board, name)$pin_hash
     if (identical(old_hash, meta$pin_hash)) {
       pins_inform(c(

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -64,10 +64,10 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #'   use the default for `board`
 #' @param tags A character vector of tags for the pin; most important for
 #'   discoverability on shared boards.
-#' @param check_hash Check whether the pin contents are identical to the last
-#'   version if one exists (using the hash), and then **do not store** the pin
-#'   again. This argument does not check the pin metadata, only the pin
-#'   contents. Defaults to `FALSE`.
+#' @param compare_hash Compare the pin contents to the last version if one
+#'   exists (using the hash), and if identical, **do not store** the pin again.
+#'   This argument does not compare any pin metadata, only the pin contents.
+#'   Defaults to `TRUE`.
 #' @rdname pin_read
 #' @export
 pin_write <- function(board, x,
@@ -79,7 +79,7 @@ pin_write <- function(board, x,
                       versioned = NULL,
                       tags = NULL,
                       ...,
-                      check_hash = FALSE) {
+                      compare_hash = TRUE) {
   ellipsis::check_dots_used()
   check_board(board, "pin_write", "pin")
 
@@ -116,7 +116,7 @@ pin_write <- function(board, x,
   )
   meta$user <- metadata
 
-  if (check_hash) {
+  if (compare_hash) {
     old_hash <- possibly_pin_meta(board, name)$pin_hash
     if (identical(old_hash, meta$pin_hash)) {
       pins_inform(c(

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -118,7 +118,7 @@ pin_write <- function(board, x,
 
   if (check_hash) {
     old_hash <- possibly_pin_meta(board, name)$pin_hash
-    if (!is.null(old_hash) && old_hash == meta$pin_hash) {
+    if (identical(old_hash, meta$pin_hash)) {
       cli::cli_warn(c(
         "!" = "The hash of pin {.val {name}} has not changed.",
         "*" = "Your pin will not be stored."

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -119,7 +119,7 @@ pin_write <- function(board, x,
   if (check_hash) {
     old_hash <- possibly_pin_meta(board, name)$pin_hash
     if (identical(old_hash, meta$pin_hash)) {
-      cli::cli_warn(c(
+      pins_inform(c(
         "!" = "The hash of pin {.val {name}} has not changed.",
         "*" = "Your pin will not be stored."
       ))

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -165,7 +165,7 @@ test_api_versioning <- function(board) {
   testthat::test_that("check_hash arg skips an identical subsequent write", {
     orig <- local_pin(board, 1, check_hash = TRUE)
     name <- local_pin(board, 1)
-    testthat::expect_warning(
+    testthat::expect_message(
       pin_write(board, 1, name, check_hash = TRUE),
       regexp = "Your pin will not be stored"
     )

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -167,7 +167,7 @@ test_api_versioning <- function(board) {
     name <- local_pin(board, 1)
     testthat::expect_warning(
       pin_write(board, 1, name, check_hash = TRUE),
-      regexp = "has not changed and will not be stored"
+      regexp = "Your pin will not be stored"
     )
   })
 

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -162,12 +162,12 @@ test_api_versioning <- function(board) {
     )
   })
 
-  testthat::test_that("compare_hash arg skips an identical subsequent write", {
-    orig <- local_pin(board, 1, compare_hash = TRUE)
-    name <- local_pin(board, 1)
+  testthat::test_that("force_identical_write arg skips an identical subsequent write", {
+    orig <- local_pin(board, 1)
+    name <- local_pin(board, 1, force_identical_write = TRUE)
     ui_loud()
     testthat::expect_message(
-      pin_write(board, 1, name, compare_hash = TRUE),
+      pin_write(board, 1, name),
       regexp = "Your pin will not be stored"
     )
   })

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -162,6 +162,15 @@ test_api_versioning <- function(board) {
     )
   })
 
+  testthat::test_that("check_hash arg skips an identical subsequent write", {
+    orig <- local_pin(board, 1, check_hash = TRUE)
+    name <- local_pin(board, 1)
+    testthat::expect_warning(
+      pin_write(board, 1, name, check_hash = TRUE),
+      regexp = "has not changed and will not be stored"
+    )
+  })
+
   testthat::test_that("unversioned write overwrites single previous version", {
     name <- local_pin(board, 1)
     pin_write(board, 2, name, versioned = FALSE)

--- a/R/testthat.R
+++ b/R/testthat.R
@@ -162,11 +162,12 @@ test_api_versioning <- function(board) {
     )
   })
 
-  testthat::test_that("check_hash arg skips an identical subsequent write", {
-    orig <- local_pin(board, 1, check_hash = TRUE)
+  testthat::test_that("compare_hash arg skips an identical subsequent write", {
+    orig <- local_pin(board, 1, compare_hash = TRUE)
     name <- local_pin(board, 1)
+    ui_loud()
     testthat::expect_message(
-      pin_write(board, 1, name, check_hash = TRUE),
+      pin_write(board, 1, name, compare_hash = TRUE),
       regexp = "Your pin will not be stored"
     )
   })

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,10 +53,10 @@ modifyList <- function(x, y) {
 
 last <- function(x) x[[length(x)]]
 
-pins_inform <- function(...) {
+pins_inform <- function(msg) {
   opt <- getOption("pins.quiet", NA)
   if (identical(opt, FALSE) || (identical(opt, NA))) {
-    inform(glue(..., .envir = caller_env()))
+    cli::cli_inform(msg, .envir = caller_env())
   }
 }
 

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -18,7 +18,7 @@ pin_write(
   versioned = NULL,
   tags = NULL,
   ...,
-  check_hash = FALSE
+  compare_hash = TRUE
 )
 }
 \arguments{
@@ -60,10 +60,10 @@ use the default for \code{board}}
 \item{tags}{A character vector of tags for the pin; most important for
 discoverability on shared boards.}
 
-\item{check_hash}{Check whether the pin contents are identical to the last
-version if one exists (using the hash), and then \strong{do not store} the pin
-again. This argument does not check the pin metadata, only the pin
-contents. Defaults to \code{FALSE}.}
+\item{compare_hash}{Compare the pin contents to the last version if one
+exists (using the hash), and if identical, \strong{do not store} the pin again.
+This argument does not compare any pin metadata, only the pin contents.
+Defaults to \code{TRUE}.}
 }
 \value{
 \code{pin_read()} returns an R object read from the pin;

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -18,7 +18,7 @@ pin_write(
   versioned = NULL,
   tags = NULL,
   ...,
-  compare_hash = TRUE
+  force_identical_write = FALSE
 )
 }
 \arguments{
@@ -60,10 +60,9 @@ use the default for \code{board}}
 \item{tags}{A character vector of tags for the pin; most important for
 discoverability on shared boards.}
 
-\item{compare_hash}{Compare the pin contents to the last version if one
-exists (using the hash), and if identical, \strong{do not store} the pin again.
-This argument does not compare any pin metadata, only the pin contents.
-Defaults to \code{TRUE}.}
+\item{force_identical_write}{Store the pin even if the pin contents are
+identical to the last version (compared using the hash). Only the pin
+contents are compared, not the pin metadata. Defaults to \code{FALSE}.}
 }
 \value{
 \code{pin_read()} returns an R object read from the pin;

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -17,7 +17,8 @@ pin_write(
   metadata = NULL,
   versioned = NULL,
   tags = NULL,
-  ...
+  ...,
+  check_hash = FALSE
 )
 }
 \arguments{
@@ -58,6 +59,10 @@ use the default for \code{board}}
 
 \item{tags}{A character vector of tags for the pin; most important for
 discoverability on shared boards.}
+
+\item{check_hash}{Check whether the pin contents are identical to the last
+version if one exists (using the hash), and then \strong{do not store} the pin
+again. Defaults to \code{FALSE}.}
 }
 \value{
 \code{pin_read()} returns an R object read from the pin;

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -62,7 +62,8 @@ discoverability on shared boards.}
 
 \item{check_hash}{Check whether the pin contents are identical to the last
 version if one exists (using the hash), and then \strong{do not store} the pin
-again. Defaults to \code{FALSE}.}
+again. This argument does not check the pin metadata, only the pin
+contents. Defaults to \code{FALSE}.}
 }
 \value{
 \code{pin_read()} returns an R object read from the pin;

--- a/tests/testthat/_snaps/board_folder.md
+++ b/tests/testthat/_snaps/board_folder.md
@@ -49,12 +49,12 @@
       Creating new version '20130104T050607Z-xxxxx'
       Writing to pin 'x'
     Code
-      pin_write(b, 1:5, "x", type = "rds")
+      pin_write(b, 1:6, "x", type = "rds")
     Message
       Replacing version '20130104T050607Z-xxxxx' with '20130204T050607Z-yyyyy'
       Writing to pin 'x'
     Code
-      pin_write(b, 1:6, "x", type = "rds")
+      pin_write(b, 1:7, "x", type = "rds")
     Message
       Replacing version '20130204T050607Z-yyyyy' with '20130304T050607Z-zzzzz'
       Writing to pin 'x'

--- a/tests/testthat/_snaps/pin_versions.md
+++ b/tests/testthat/_snaps/pin_versions.md
@@ -33,7 +33,7 @@
 
     Code
       board %>% pin_write(1:10, "x")
-      board %>% pin_write(1:10, "x", compare_hash = FALSE)
+      board %>% pin_write(1:10, "x", force_identical_write = TRUE)
     Condition
       Error in `pin_store()`:
       ! The new version "20120304T050607Z-xxxxx" is the same as the most recent version.

--- a/tests/testthat/_snaps/pin_versions.md
+++ b/tests/testthat/_snaps/pin_versions.md
@@ -33,7 +33,7 @@
 
     Code
       board %>% pin_write(1:10, "x")
-      board %>% pin_write(1:10, "x")
+      board %>% pin_write(1:10, "x", compare_hash = FALSE)
     Condition
       Error in `pin_store()`:
       ! The new version "20120304T050607Z-xxxxx" is the same as the most recent version.

--- a/tests/testthat/test-board_connect.R
+++ b/tests/testthat/test-board_connect.R
@@ -46,11 +46,11 @@ test_that("can update access_type", {
   # default is acl
   expect_equal(rsc_content_info(board, guid)$access_type, "acl")
 
-  pin_write(board, 1:5, name, access_type = "logged_in")
+  pin_write(board, 1:6, name, access_type = "logged_in")
   expect_equal(rsc_content_info(board, guid)$access_type, "logged_in")
 
   # writing again doesn't change the access_type
-  pin_write(board, 1:5, name)
+  pin_write(board, 1:7, name)
   expect_equal(rsc_content_info(board, guid)$access_type, "logged_in")
 })
 

--- a/tests/testthat/test-board_folder.R
+++ b/tests/testthat/test-board_folder.R
@@ -87,7 +87,7 @@ test_that("generates useful messages", {
   b <- board_temp()
   expect_snapshot({
     pin_write(b, 1:5, "x", type = "rds")
-    pin_write(b, 1:5, "x", type = "rds")
     pin_write(b, 1:6, "x", type = "rds")
+    pin_write(b, 1:7, "x", type = "rds")
   })
 })

--- a/tests/testthat/test-pin_versions.R
+++ b/tests/testthat/test-pin_versions.R
@@ -40,7 +40,7 @@ test_that("informative error for writing with same version", {
   board <- board_temp(versioned = TRUE)
   expect_snapshot(error = TRUE, {
     board %>% pin_write(1:10, "x")
-    board %>% pin_write(1:10, "x")
+    board %>% pin_write(1:10, "x", compare_hash = FALSE)
   })
 })
 

--- a/tests/testthat/test-pin_versions.R
+++ b/tests/testthat/test-pin_versions.R
@@ -40,7 +40,7 @@ test_that("informative error for writing with same version", {
   board <- board_temp(versioned = TRUE)
   expect_snapshot(error = TRUE, {
     board %>% pin_write(1:10, "x")
-    board %>% pin_write(1:10, "x", compare_hash = FALSE)
+    board %>% pin_write(1:10, "x", force_identical_write = TRUE)
   })
 })
 


### PR DESCRIPTION
Addresses #589 

This does not solve all our hashing issues (for example, the `pin_hash` still only looks at the pin _contents_ and not the metadata) but it is a small step toward a better hashing situation.

After talking with users, I think that an opt-in new argument is the best way forward (rather than, say, a new function or new default behavior). This new `check_hash` arg comes after the dots and defaults to `FALSE`. It does require another read of `pin_meta()` to get the old hash.

``` r
library(pins)
b <- board_temp(versioned = TRUE)
b %>% pin_write(1:10, "nice-numbers", check_hash = TRUE)
#> Guessing `type = 'rds'`
#> Creating new version '20230426T224520Z-7f884'
#> Writing to pin 'nice-numbers'

## to change timestamp:
Sys.sleep(2)

b %>% pin_write(1:10, "nice-numbers", check_hash = TRUE)
#> Guessing `type = 'rds'`
#> Warning: The hash of pin "nice-numbers" has not changed and will not be stored.
```

<sup>Created on 2023-04-26 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

With this PR as is now, `pin_write()` will still return the name invisibly but does not store the pin and generates a warning. Thoughts?


