### PR TITLE
Make API version in metadata more consistent

### DIFF
--- a/R/meta.R
+++ b/R/meta.R
@@ -16,8 +16,8 @@ read_meta <- function(path) {
     yaml$created <- parse_8601_compact(yaml$created)
     yaml$user <- yaml$user %||% list()
   } else if (yaml$api_version > 1) {
-    abort(c(
-      paste0("Metadata requires pins ", yaml$api_version),
+    cli::cli_abort(c(
+      "Metadata requires pins {yaml$api_version}.0.0 or greater",
       i = "Do you need to upgrade the pins package?"
     ))
   }

--- a/R/meta.R
+++ b/R/meta.R
@@ -17,7 +17,7 @@ read_meta <- function(path) {
     yaml$user <- yaml$user %||% list()
   } else if (yaml$api_version > 1) {
     abort(c(
-      paste0("Metadata requires pins ", yaml$api_version, ".0.0 or greater"),
+      paste0("Metadata requires pins ", yaml$api_version),
       i = "Do you need to upgrade the pins package?"
     ))
   }
@@ -46,7 +46,7 @@ standard_meta <- function(paths,
     description = description,
     tags = if (is.null(tags)) tags else as.list(tags),
     created = format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC"),
-    api_version = 1
+    api_version = 1L
   )
 }
 

--- a/R/pin-meta.R
+++ b/R/pin-meta.R
@@ -143,7 +143,7 @@ test_api_meta <- function(board) {
     testthat::expect_true(meta$type %in% object_types)
     testthat::expect_vector(meta$title, character(), 1)
     testthat::expect_vector(meta$created, .POSIXct(double()), 1)
-    testthat::expect_vector(meta$api_version, double(), 1)
+    testthat::expect_vector(meta$api_version, integer(), 1)
 
     testthat::expect_vector(meta$user, list())
     testthat::expect_vector(meta$local, list())

--- a/tests/testthat/_snaps/meta.md
+++ b/tests/testthat/_snaps/meta.md
@@ -9,7 +9,7 @@
      $ description: NULL
      $ tags       : NULL
      $ created    : chr "<TODAY>"
-     $ api_version: num 1
+     $ api_version: int 1
 
 # newer version triggers error
 


### PR DESCRIPTION
Closes #612 

This PR makes the API version (currently, possible values are 0 and 1, or it can be absent for old pins) stored in the metadata more consistent, i.e. stored and read as int.

The error message is intended to communicate about the package version (e.g. 1.1.0.9000 right now) to the user. The API stored in the metadata is more like an internal value and the package version is more like an external value. If we ever drastically changed the user-facing API again, we would bump the package version to 2.0.0, `api_version` to 2, and go from there.