### PR TITLE
Switch to webfakes httpbin

### DIFF
--- a/R/testthat.R
+++ b/R/testthat.R
@@ -209,6 +209,14 @@ test_api_manifest <- function(board) {
 
 }
 
+local_httpbin_app <- function() {
+  rlang::check_installed("webfakes")
+  webfakes::local_app_process(
+    webfakes::httpbin_app(),
+    .local_envir = testthat::teardown_env()
+  )
+}
+
 # errors live here for now since they're closely bound to the tests
 
 abort_pin_missing <- function(name, call = caller_env()) {

--- a/tests/testthat/_snaps/pin.md
+++ b/tests/testthat/_snaps/pin.md
@@ -1,17 +1,17 @@
 # unavailable url can use cache
 
     Code
-      pin("http://httpbin.org/status/404", "test", board = board)
+      pin(url, "test", board = board)
     Condition
       Error in `pin()`:
-      ! Client error: (404) Not Found. Failed to download remote file: http://httpbin.org/status/404
+      ! Client error: (404) Not Found. Failed to download remote file: http://127.0.0.1:<port>/status/404
     Code
       pin(1:10, "test", board = board)
-      x <- pin("http://httpbin.org/status/404", "test", board = board)
+      x <- pin(url, "test", board = board)
     Condition
       Warning:
       Failed to re-download pin; using cached value
-      * Client error: (404) Not Found. Failed to download remote file: http://httpbin.org/status/404
+      * Client error: (404) Not Found. Failed to download remote file: http://127.0.0.1:<port>/status/404
     Code
       expect_equal(x, 1:10)
 

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,13 +1,2 @@
 options(pins.verbose = FALSE)
 options(pins.quiet = TRUE)
-
-httpbin <- webfakes::local_app_process(
-  if (rlang::is_installed("webfakes")) webfakes::httpbin_app(),
-  .local_envir = testthat::teardown_env()
-)
-
-httpbin_port <- if (rlang::is_installed("webfakes")) httpbin$get_port()
-
-redact_port <- function(snapshot) {
-  snapshot <- gsub(httpbin_port, "<port>", snapshot, fixed = TRUE)
-}

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -6,6 +6,8 @@ httpbin <- webfakes::local_app_process(
   .local_envir = testthat::teardown_env()
 )
 
+httpbin_port <- if (rlang::is_installed("webfakes")) httpbin$get_port()
+
 redact_port <- function(snapshot) {
-  snapshot <- gsub(httpbin$get_port(), "<port>", snapshot, fixed = TRUE)
+  snapshot <- gsub(httpbin_port, "<port>", snapshot, fixed = TRUE)
 }

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,2 +1,11 @@
 options(pins.verbose = FALSE)
 options(pins.quiet = TRUE)
+
+httpbin <- webfakes::local_app_process(
+  if (rlang::is_installed("webfakes")) webfakes::httpbin_app(),
+  .local_envir = testthat::teardown_env()
+)
+
+redact_port <- function(snapshot) {
+  snapshot <- gsub(httpbin$get_port(), "<port>", snapshot, fixed = TRUE)
+}

--- a/tests/testthat/test-pin.R
+++ b/tests/testthat/test-pin.R
@@ -1,4 +1,5 @@
 skip_if_not_installed("filelock")
+skip_if_not_installed("webfakes")
 
 # main types --------------------------------------------------------------
 
@@ -68,13 +69,14 @@ test_that("can pin() remote CSV with URL and name", {
 test_that("unavailable url can use cache", {
   skip_on_cran()
   board <- legacy_temp()
+  url <- httpbin$url("/status/404")
 
-  expect_snapshot(error = TRUE, {
-    pin("http://httpbin.org/status/404", "test", board = board)
+  expect_snapshot({
+    pin(url, "test", board = board)
     pin(1:10, "test", board = board)
-    x <- pin("http://httpbin.org/status/404", "test", board = board)
+    x <- pin(url, "test", board = board)
     expect_equal(x, 1:10)
-  })
+  }, error = TRUE, transform = redact_port)
 })
 
 # custom metadata -------------------------------------------------------------------

--- a/tests/testthat/test-pin.R
+++ b/tests/testthat/test-pin.R
@@ -1,6 +1,12 @@
 skip_if_not_installed("filelock")
 skip_if_not_installed("webfakes")
 
+httpbin <- local_httpbin_app()
+httpbin_port <- httpbin$get_port()
+redact_port <- function(snapshot) {
+  snapshot <- gsub(httpbin_port, "<port>", snapshot, fixed = TRUE)
+}
+
 # main types --------------------------------------------------------------
 
 test_that("can pin() a data frame", {


### PR DESCRIPTION
This PR only switches over the old `pin()` tests, but when `/cache` and `/etag` are added as outlined in r-lib/webfakes#3 then I can switch over the `board_url()` tests.