### PR TITLE
Add new `PINS_CACHE_PATH` env var, plus documentation

### DIFF
--- a/R/board.R
+++ b/R/board.R
@@ -84,22 +84,47 @@ cache_size <- function(board) {
 
 is.board <- function(x) inherits(x, "pins_board")
 
-#' Retrieve Default Cache Path
+#' Retrieve default cache path
 #'
 #' Retrieves the default path used to cache boards and pins. Makes
-#' use of the `rappdirs` package to use cache folders
-#' defined by each OS.
+#' use of [rappdirs::user_cache_dir()] for cache folders defined by each OS.
+#' Remember that you can set the cache location for an individual board object
+#' via the `cache` argument.
 #'
 #' @param name Board name
-#' @keywords internal
+#' @details
+#' There are several environment variables available to control the location of
+#' the default pins cache:
+#'
+#' - Use `PINS_CACHE_PATH` to set the cache path for _only_ pins functions
+#' - Use `R_USER_CACHE_DIR` to set the cache path for all functions that use rappdirs
+#'
+#' On system like AWS Lambda that is read only (for example, only `/tmp` is
+#' writeable), set either of these to [base::tempdir()]. You may also need to
+#' set environment variables like `HOME` and/or `R_USER_DATA_DIR` to the
+#' session temporary directory.
+#'
 #' @examples
 #' # retrieve default cache path
 #' board_cache_path("local")
+#'
+#' # set with env vars:
+#' withr::with_envvar(
+#'     c("PINS_CACHE_PATH" = "/path/to/cache"),
+#'     board_cache_path("local")
+#' )
+#' withr::with_envvar(
+#'     c("R_USER_CACHE_DIR" = "/path/to/cache"),
+#'     board_cache_path("local")
+#' )
+#'
 #' @export
 board_cache_path <- function(name) {
   # R_CONFIG_ACTIVE suggests we're in a production environment
   if (has_envvars("R_CONFIG_ACTIVE") || has_envvars("PINS_USE_CACHE")) {
-    path <- tempfile()
+    path <- tempdir()
+  } else if (has_envvars("PINS_CACHE_PATH") ) {
+    path <- Sys.getenv("PINS_CACHE_PATH")
   } else {
     path <- cache_dir()
   }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -47,6 +47,7 @@ reference:
 - title: Other functions
   contents:
   - cache_browse
+  - board_cache_path
   - write_board_manifest
 
 - title: Legacy API

--- a/man/board_cache_path.Rd
+++ b/man/board_cache_path.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/board.R
 \name{board_cache_path}
 \alias{board_cache_path}
-\title{Retrieve Default Cache Path}
+\title{Retrieve default cache path}
 \usage{
 board_cache_path(name)
 }
@@ -11,11 +11,35 @@ board_cache_path(name)
 }
 \description{
 Retrieves the default path used to cache boards and pins. Makes
-use of the \code{rappdirs} package to use cache folders
-defined by each OS.
+use of \code{\link[rappdirs:user_cache_dir]{rappdirs::user_cache_dir()}} for cache folders defined by each OS.
+Remember that you can set the cache location for an individual board object
+via the \code{cache} argument.
+}
+\details{
+There are several environment variables available to control the location of
+the default pins cache:
+\itemize{
+\item Use \code{PINS_CACHE_PATH} to set the cache path for \emph{only} pins functions
+\item Use \code{R_USER_CACHE_DIR} to set the cache path for all functions that use rappdirs
+}
+
+On system like AWS Lambda that is read only (for example, only \verb{/tmp} is
+writeable), set either of these to \code{\link[base:tempfile]{base::tempdir()}}. You may also need to
+set environment variables like \code{HOME} and/or \code{R_USER_DATA_DIR} to the
+session temporary directory.
 }
 \examples{
 # retrieve default cache path
 board_cache_path("local")
+
+# set with env vars:
+withr::with_envvar(
+    c("PINS_CACHE_PATH" = "/path/to/cache"),
+    board_cache_path("local")
+)
+withr::with_envvar(
+    c("R_USER_CACHE_DIR" = "/path/to/cache"),
+    board_cache_path("local")
+)
+
 }
-\keyword{internal}


### PR DESCRIPTION
Closes #747 

With these changes, we can now use an environment variable to specify where the cache goes:

``` r
withr::local_envvar(list("PINS_CACHE_PATH" = "~/Desktop"))
server <- pins:::rsc_server(auth = "envvar")
pins::board_cache_path(paste0("connect-", rlang::hash(server$url)))
#> ~/Desktop/connect-31a399613ac85efda77ffe6ff20c105a
```

<sup>Created on 2023-06-02 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

This also finally fixes #611 by documenting how the env variables work, with some advice on a read-only filesystem like AWS Lambda.