### PR TITLE
Update test for new arrow release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
   
 * Added new board for Google Drive `board_gdrive()` (#749).
 
+* Updated test for new arrow release (#764).
+
 # pins 1.2.0
 
 ## Breaking changes

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -4,7 +4,7 @@ test_that("can round trip all types", {
   board <- board_temp()
 
   # Data frames
-  df <- data.frame(x = 1:10)
+  df <- tibble::tibble(x = 1:10)
   pin_write(board, df, "df-1", type = "rds")
   expect_equal(pin_read(board, "df-1"), df)
 
@@ -12,13 +12,13 @@ test_that("can round trip all types", {
   expect_equal(pin_read(board, "df-2"), df)
 
   pin_write(board, df, "df-3", type = "arrow")
-  expect_equal(pin_read(board, "df-2"), df)
-
-  pin_write(board, df, "df-4", type = "csv")
   expect_equal(pin_read(board, "df-3"), df)
 
+  pin_write(board, df, "df-4", type = "csv")
+  expect_equal(pin_read(board, "df-4"), as.data.frame(df))
+
   pin_write(board, df, "df-5", type = "qs")
-  expect_equal(pin_read(board, "df-4"), df)
+  expect_equal(pin_read(board, "df-5"), df)
 
   # List
   x <- list(a = 1:5, b = 1:10)


### PR DESCRIPTION
Closes #761 

This PR changes the read 🔄 write tests to use `tibble::tibble()` to account for the new behavior in arrow, which now always returns a tibble on reading. If you write a tibble, only the CSV storage option now returns a `data.frame`. I went back and forth on how to handle this change, but I now think the best thing to do is to keep the same behavior in pins that arrow has.

This PR works with both old and new arrow, so we could do a release whenever. I tested locally with the devel version of arrow.