### PR TITLE
Move ellipsis checking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pins (development version)
 
+* Fixed how dots are checked in `pin_write()` to make user-facing messages more 
+  clear (#770).
+
 # pins 1.2.1
 
 * New environment variable `PINS_CACHE_DIR` controls the location of the 

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -79,7 +79,6 @@ pin_write <- function(board, x,
                       tags = NULL,
                       ...,
                       force_identical_write = FALSE) {
-  ellipsis::check_dots_used()
   check_board(board, "pin_write", "pin")
 
   if (is.null(name)) {
@@ -126,6 +125,7 @@ pin_write <- function(board, x,
     }
   }
 
+  ellipsis::check_dots_used()
   name <- pin_store(board, name, path, meta, versioned = versioned, x = x, ...)
   pins_inform("Writing to pin '{name}'")
   invisible(name)


### PR DESCRIPTION
Closes #760 

This PR moves the ellipsis checking to _after_ the early return when we don't write. The messaging now looks like this:

``` r
library(pins)
b <- board_connect()
#> Connecting to Posit Connect 2023.07.0 at <https://colorado.posit.co/rsc>

b |> pin_write(
  1:10, 
  "julia.silge/some-amazing-numbers",
  access_type = "all"
)
#> Guessing `type = 'rds'`
#> ! The hash of pin "julia.silge/some-amazing-numbers" has not changed.
#> • Your pin will not be stored.
```

<sup>Created on 2023-08-28 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>