### PR TITLE
Add documentation for how to clear Connect caches

### DIFF
--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -30,8 +30,16 @@
 #' ))
 #' board %>% pin_read("numbers")
 #' ```
-#'
+#' 
 #' You can find the URL of a pin with [pin_browse()].
+#' 
+#' # Caching on Posit Connect
+#' 
+#' The pins package maintains per-session caches for _users_ and _content_ on
+#' your Connect server. If your cache gets into a bad state (for example, user
+#' names have changed on the server or a pin was deleted on the server, but 
+#' your local machine doesn't know about the change yet), you can clear you local
+#' cache by restarting your R session.
 #'
 #' @inheritParams new_board
 #' @inheritParams board_url

--- a/man/board_connect.Rd
+++ b/man/board_connect.Rd
@@ -104,6 +104,14 @@ board \%>\% pin_read("numbers")
 You can find the URL of a pin with \code{\link[=pin_browse]{pin_browse()}}.
 }
 
+\section{Caching on Posit Connect}{
+The pins package maintains per-session caches for \emph{users} and \emph{content} on
+your Connect server. If your cache gets into a bad state (for example, user
+names have changed on the server or a pin was deleted on the server, but
+your local machine doesn't know about the change yet), you can clear you local
+cache by restarting your R session.
+}
+
 \examples{
 \dontrun{
 board <- board_connect()


### PR DESCRIPTION
During our internal migration of our Connect server, we realized that folks need clearer info on Connect pins caches. Let's add this on the `board_connect()` doc page.