### PR TITLE
Use a dribble to define the upload destination path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 
 * Added `board_deparse` for `board_url()` (#774).
 
+* Fixed how `board_gdrive()` makes version directories (#780, @gorkang).
+
 
 # pins 1.2.1
 

--- a/R/board_gdrive.R
+++ b/R/board_gdrive.R
@@ -140,20 +140,23 @@ pin_store.pins_board_gdrive <- function(board, name, paths, metadata,
   gdrive_mkdir(fs::path(board$dribble$name, name), version)
 
   version_dir <- fs::path(name, version)
+  version_dir_dribble = googledrive::as_dribble(version_dir)
 
   # Upload metadata
   temp_file <- withr::local_tempfile()
   yaml::write_yaml(metadata, file = temp_file)
   googledrive::drive_upload(
     temp_file,
-    fs::path(board$dribble$path, version_dir, "data.txt")
+    version_dir_dribble,
+    "data.txt"
   )
 
   # Upload files
   for (path in paths) {
     googledrive::drive_upload(
       path,
-      fs::path(board$dribble$path, version_dir, fs::path_file(path))
+      version_dir_dribble,
+      fs::path_file(path)
     )
   }
 


### PR DESCRIPTION
This is a potential fix to #777 

Instead of passing a full path to `drive_upload`, with this pr we first create a dribble with the destination folder, and then use it as a path. 

In my computer, it works with a single or multiple files, uploading to the main google drive folder or to  folder with a long path.

For example, now this works without any issues:
```
drive_link = "https://drive.google.com/drive/folders/1_jiG0VtENy5QcLRziN7DM_zQD4egwGuN"
googledrive::drive_auth(email = "myemail@gmail.com")
gdrive_board = pins::board_gdrive(drive_link)
gdrive_board |> pins::pin_upload(paths = "~/Downloads/999.zip", name = "Id_pin")
```
