### PR TITLE
Fix how `board_gdrive()` uses dribble components

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 * Added `board_deparse` for `board_url()` (#774).
 
-* Fixed how `board_gdrive()` makes version directories (#780, @gorkang).
+* Fixed how `board_gdrive()` handles dribble objects (#780, @gorkang and #782).
 
 
 # pins 1.2.1

--- a/R/board_gdrive.R
+++ b/R/board_gdrive.R
@@ -189,10 +189,14 @@ possibly_drive_ls <- function(...) {
 }
 
 gdrive_file_exists <- function(board, name) {
-  path <- fs::path(board$dribble$name, fs::path_dir(name))
+  dribble <- googledrive::drive_ls(board$dribble)
+  path_components <- purrr::pluck(fs::path_split(fs::path_dir(name)), 1)
+  for (path_component in path_components) {
+    dribble <- dribble[dribble$name == path_component,]
+    dribble <- possibly_drive_ls(dribble)
+  }
   name <- fs::path_file(name)
-  all_names <- possibly_drive_ls(path)
-  name %in% all_names$name
+  name %in% dribble$name
 }
 
 gdrive_download <- function(board, key) {

--- a/R/board_gdrive.R
+++ b/R/board_gdrive.R
@@ -202,7 +202,10 @@ gdrive_file_exists <- function(board, name) {
 gdrive_download <- function(board, key) {
   path <- fs::path(board$cache, key)
   if (!fs::file_exists(path)) {
-    googledrive::drive_download(key, path)
+    dribble <- googledrive::as_dribble(fs::path_dir(key))
+    dribble <- googledrive::drive_ls(dribble)
+    dribble <- dribble[dribble$name == fs::path_file(key),]
+    googledrive::drive_download(dribble, path)
     fs::file_chmod(path, "u=r")
   }
   path

--- a/R/board_gdrive.R
+++ b/R/board_gdrive.R
@@ -77,7 +77,6 @@ pin_delete.pins_board_gdrive <- function(board, names, ...) {
     dribble <- googledrive::drive_ls(board$dribble)
     dribble <- dribble[dribble$name == name,]
     googledrive::drive_trash(dribble)
-    invisible()
   }
   invisible(board)
 }

--- a/R/board_gdrive.R
+++ b/R/board_gdrive.R
@@ -66,7 +66,7 @@ pin_list.pins_board_gdrive <- function(board, ...) {
 
 #' @export
 pin_exists.pins_board_gdrive <- function(board, name, ...) {
-  all_names <- googledrive::drive_ls(board$dribble$name)$name
+  all_names <- googledrive::drive_ls(board$dribble)$name
   name %in% all_names
 }
 
@@ -74,20 +74,31 @@ pin_exists.pins_board_gdrive <- function(board, name, ...) {
 pin_delete.pins_board_gdrive <- function(board, names, ...) {
   for (name in names) {
     check_pin_exists(board, name)
-    gdrive_delete_dir(board, name)
+    dribble <- googledrive::drive_ls(board$dribble)
+    dribble <- dribble[dribble$name == name,]
+    googledrive::drive_trash(dribble)
+    invisible()
   }
   invisible(board)
 }
 
 #' @export
 pin_version_delete.pins_board_gdrive <- function(board, name, version, ...) {
-  gdrive_delete_dir(board, fs::path(name, version))
+  check_pin_exists(board, name)
+  pin_dribble <- googledrive::drive_ls(board$dribble)
+  pin_dribble <- pin_dribble[pin_dribble$name == name,]
+  version_dribble <- googledrive::drive_ls(pin_dribble)
+  version_dribble <- version_dribble[version_dribble$name == version,]
+  googledrive::drive_trash(version_dribble)
+  invisible()
 }
 
 #' @export
 pin_versions.pins_board_gdrive <- function(board, name, ...) {
   check_pin_exists(board, name)
-  path <- fs::path(board$dribble$path, name)
+  dribble <- googledrive::drive_ls(board$dribble)
+  dribble <- dribble[dribble$name == name,]
+  path <- googledrive::as_dribble(dribble)
   version_from_path(sort(googledrive::drive_ls(path)$name))
 }
 
@@ -183,12 +194,6 @@ gdrive_file_exists <- function(board, name) {
   name <- fs::path_file(name)
   all_names <- possibly_drive_ls(path)
   name %in% all_names$name
-}
-
-gdrive_delete_dir <- function(board, dir) {
-  path <- fs::path(board$dribble$path, dir)
-  googledrive::drive_trash(path)
-  invisible()
 }
 
 gdrive_download <- function(board, key) {


### PR DESCRIPTION
Closes #781 

When I first put together the support for the Google Drive board, I did not pay enough attention to what is guaranteed to come in a dribble object:
https://googledrive.tidyverse.org/reference/dribble.html

This PR addresses this more holistically than #780, throughout all the methods. I don't think I want to change my general testing strategy, but I did just locally run through this (after running `devtools::load_all()`):

```r
my_dribble <- googledrive::as_dribble("https://drive.google.com/drive/u/1/folders/1GQ-JuG4pT1AK9VLz9UZptnO73H7zDaUe")
board <- board_gdrive(my_dribble)
test_api_basic(board)
test_api_versioning(board)
test_api_meta(board)
```

All these tests pass and I expect this to now work much better.
