### PR TITLE
Change the `pin_write()` function signature, moving the dots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pins (development version)
 
+* Changed the function signature of `pin_write()` so arguments like `type` and `title` must be passed by name and not position (#792).
+
 # pins 1.2.2
 
 * Fixed how dots are checked in `pin_write()` to make user-facing messages more 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
-# pins (development version)
+# pins (development version to be released as 1.3.0)
+
+## Breaking changes
 
 * Changed the function signature of `pin_write()` so arguments like `type` and `title` must be passed by name and not position (#792).
 

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -71,15 +71,19 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #' @export
 pin_write <- function(board, x,
                       name = NULL,
+                      ...,
                       type = NULL,
                       title = NULL,
                       description = NULL,
                       metadata = NULL,
                       versioned = NULL,
                       tags = NULL,
-                      ...,
                       force_identical_write = FALSE) {
   check_board(board, "pin_write", "pin")
+  dots <- list2(...)
+  if (!is_empty(dots) && is.null(names(dots[1]))) {
+    cli::cli_abort('The {.arg type} argument must be named, like {.code type = "{dots[[1]]}"}.')
+  }
 
   if (is.null(name)) {
     name <- enexpr(x)

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -82,7 +82,7 @@ pin_write <- function(board, x,
   check_board(board, "pin_write", "pin")
   dots <- list2(...)
   if (!is_empty(dots) && is.null(names(dots[1]))) {
-    cli::cli_abort('The {.arg type} argument must be named, like {.code type = "{dots[[1]]}"}.')
+    cli::cli_abort('Arguments after the dots `...` must be named, like {.code type = "{dots[[1]]}"}.')
   }
 
   if (is.null(name)) {

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -80,7 +80,8 @@ pin_write <- function(board, x,
                       tags = NULL,
                       force_identical_write = FALSE) {
   check_board(board, "pin_write", "pin")
-  if (!missing(...) && (is.null(...names()) || ...names()[[1]] == "")) {
+  dots <- list2(...)
+  if (!missing(...) && (is.null(names(dots)) || names(dots)[[1]] == "")) {
     cli::cli_abort('Arguments after the dots `...` must be named, like {.code type = "json"}.')
   }
 

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -80,9 +80,8 @@ pin_write <- function(board, x,
                       tags = NULL,
                       force_identical_write = FALSE) {
   check_board(board, "pin_write", "pin")
-  dots <- list2(...)
-  if (!is_empty(dots) && is.null(names(dots[1]))) {
-    cli::cli_abort('Arguments after the dots `...` must be named, like {.code type = "{dots[[1]]}"}.')
+  if (!missing(...) && (is.null(...names()) || ...names()[[1]] == "")) {
+    cli::cli_abort('Arguments after the dots `...` must be named, like {.code type = "json"}.')
   }
 
   if (is.null(name)) {

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -11,13 +11,13 @@ pin_write(
   board,
   x,
   name = NULL,
+  ...,
   type = NULL,
   title = NULL,
   description = NULL,
   metadata = NULL,
   versioned = NULL,
   tags = NULL,
-  ...,
   force_identical_write = FALSE
 )
 }

--- a/tests/testthat/_snaps/pin-read-write.md
+++ b/tests/testthat/_snaps/pin-read-write.md
@@ -20,6 +20,11 @@
       Error in `pin_write()`:
       ! `name` must be a string
     Code
+      pin_write(board, mtcars, name = 1:10, "json")
+    Condition
+      Error in `pin_write()`:
+      ! The `type` argument must be named, like `type = "json"`.
+    Code
       pin_write(board, mtcars, name = "mtcars", type = "froopy-loops")
     Condition
       Error in `object_write()`:

--- a/tests/testthat/_snaps/pin-read-write.md
+++ b/tests/testthat/_snaps/pin-read-write.md
@@ -23,7 +23,7 @@
       pin_write(board, mtcars, name = 1:10, "json")
     Condition
       Error in `pin_write()`:
-      ! The `type` argument must be named, like `type = "json"`.
+      ! Arguments after the dots `...` must be named, like `type = "json"`.
     Code
       pin_write(board, mtcars, name = "mtcars", type = "froopy-loops")
     Condition

--- a/tests/testthat/_snaps/pin-read-write.md
+++ b/tests/testthat/_snaps/pin-read-write.md
@@ -20,7 +20,7 @@
       Error in `pin_write()`:
       ! `name` must be a string
     Code
-      pin_write(board, mtcars, name = 1:10, "json")
+      pin_write(board, mtcars, name = "mtcars", "json")
     Condition
       Error in `pin_write()`:
       ! Arguments after the dots `...` must be named, like `type = "json"`.

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -41,7 +41,7 @@ test_that("useful errors on bad inputs", {
   expect_snapshot(error = TRUE, {
     pin_write(mtcars)
     pin_write(board, mtcars, name = 1:10)
-    pin_write(board, mtcars, name = 1:10, "json")
+    pin_write(board, mtcars, name = "mtcars", "json")
     pin_write(board, mtcars, name = "mtcars", type = "froopy-loops")
     pin_write(board, mtcars, name = "mtcars", metadata = 1)
   })

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -41,6 +41,7 @@ test_that("useful errors on bad inputs", {
   expect_snapshot(error = TRUE, {
     pin_write(mtcars)
     pin_write(board, mtcars, name = 1:10)
+    pin_write(board, mtcars, name = 1:10, "json")
     pin_write(board, mtcars, name = "mtcars", type = "froopy-loops")
     pin_write(board, mtcars, name = "mtcars", metadata = 1)
   })
@@ -65,7 +66,7 @@ test_that("pin_write() noisily generates name and type", {
 test_that("user can supply metadata", {
   board <- board_temp()
 
-  pin_write(board, 1:10, "x", metadata = list(name = "Susan"), desc = "A vector")
+  pin_write(board, 1:10, "x", metadata = list(name = "Susan"), description = "A vector")
   meta <- pin_meta(board, "x")
   expect_equal(meta$user, list(name = "Susan"))
   expect_equal(meta$description, "A vector")


### PR DESCRIPTION
We've been talking about `...` being in the wrong place for quite a while, and we think it's time to rip the band-aid off for a better experience for people. 

Technically we "should" put the dots _before_ `name` but it is very very very common for folks to provide `name` by position (without `name = `). We do it in all our docs and tests, and I believe it is very common with users as well. I would like to propose that we move the dots to between `name` and `type`, as it will not be too disruptive for users and we'll be able to get to our better situation of moving around or adding args after the dots.

The new error that folks see if they are passing by position is this:

``` r
library(pins)
board <- board_temp()
board |> pin_write(10:20, "nice-numbers", "json", "my great title")
#> Error in `pin_write()`:
#> ! Arguments after the dots `...` must be named, like `type = "json"`.
#> Backtrace:
#>     ▆
#>  1. └─pins::pin_write(board, 10:20, "nice-numbers", "json", "my great title")
#>  2.   └─cli::cli_abort("Arguments after the dots `...` must be named, like {.code type = \"{dots[[1]]}\"}.") at pins-r/R/pin-read-write.R:85:4
#>  3.     └─rlang::abort(...)
```
<sup>Created on 2023-09-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

The message doesn't make quite as much sense if people are using a mix of calling by name and position, but surely this must be rare:

``` r
library(pins)
board <- board_temp()
board |> pin_write(10:20, name = "nice-numbers", type = "json", "my great title")
#> Error in `pin_write()`:
#> ! Arguments after the dots `...` must be named, like `type = "my great
#>   title"`.
#> Backtrace:
#>     ▆
#>  1. └─pins::pin_write(board, 10:20, name = "nice-numbers", type = "json", "my great title")
#>  2.   └─cli::cli_abort("Arguments after the dots `...` must be named, like {.code type = \"{dots[[1]]}\"}.") at pins-r/R/pin-read-write.R:85:4
#>  3.     └─rlang::abort(...)
```

<sup>Created on 2023-09-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

At least they are still getting an error with some helpful info, even if it isn't as fully helpful.
