### PR TITLE
Finally rip out these Connect user and content caches

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Changed the function signature of `pin_write()` so arguments like `type` and `title` must be passed by name and not position (#792).
 
+## Other improvements
+
 * Removed content and user caches for Connect altogether. Now, we look up 
   usernames and content on the Connect server every time (#793).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pins (development version)
 
+* Removed content and user caches for Connect altogether. Now, we look up 
+  usernames and content on the Connect server every time (#793).
+
 # pins 1.2.2
 
 * Fixed how dots are checked in `pin_write()` to make user-facing messages more 

--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -30,16 +30,8 @@
 #' ))
 #' board %>% pin_read("numbers")
 #' ```
-#' 
-#' You can find the URL of a pin with [pin_browse()].
 #'
-#' # Local caching for Posit Connect
-#' 
-#' The pins package maintains local per-session caches for _users_ and _content_ 
-#' from your Connect server. If your cache gets into a bad state (for example, 
-#' user names have changed on the server or a pin was deleted on the server, but 
-#' your local machine doesn't know about the change yet), you can clear your 
-#' local cache by restarting your R session.
+#' You can find the URL of a pin with [pin_browse()].
 #'
 #' @inheritParams new_board
 #' @inheritParams board_url
@@ -437,21 +429,9 @@ board_pin_find.pins_board_connect <- function(board,
 
 # Content -----------------------------------------------------------------
 
-the <- rlang::new_environment()
-the$connect_content_cache <- rlang::new_environment()
-the$connect_user_cache <- rlang::new_environment()
-
 rsc_content_find <- function(board, name, version = NULL, warn = TRUE) {
-  name <- rsc_parse_name(name)
-  content <- rlang::env_cache(
-    env = the$connect_content_cache,
-    nm = name$full %||% name$name,
-    default = rsc_content_find_live(board, name, version = NULL, warn = TRUE)
-  )
-  content
-}
 
-rsc_content_find_live <- function(board, name, version = NULL, warn = TRUE) {
+  name <- rsc_parse_name(name)
 
   # https://docs.rstudio.com/connect/api/#get-/v1/content
   json <- rsc_GET(board, "v1/content", list(name = name$name))
@@ -573,7 +553,6 @@ rsc_content_version_cached <- function(board, guid) {
 rsc_content_delete <- function(board, name) {
   content <- rsc_content_find(board, name)
   rsc_DELETE(board, rsc_v1("content", content$guid))
-  env_unbind(the$connect_content_cache, name)
   invisible(NULL)
 }
 
@@ -588,11 +567,7 @@ rsc_parse_name <- function(x) {
 }
 
 rsc_user_name <- function(board, guid) {
-  rlang::env_cache(
-    env = the$connect_user_cache,
-    nm = guid,
-    rsc_GET(board, rsc_v1("users", guid))$username
-  )
+  rsc_GET(board, rsc_v1("users", guid))$username
 }
 
 # helpers -----------------------------------------------------------------

--- a/man/board_connect.Rd
+++ b/man/board_connect.Rd
@@ -104,14 +104,6 @@ board \%>\% pin_read("numbers")
 You can find the URL of a pin with \code{\link[=pin_browse]{pin_browse()}}.
 }
 
-\section{Local caching for Posit Connect}{
-The pins package maintains local per-session caches for \emph{users} and \emph{content}
-from your Connect server. If your cache gets into a bad state (for example,
-user names have changed on the server or a pin was deleted on the server, but
-your local machine doesn't know about the change yet), you can clear your
-local cache by restarting your R session.
-}
-
 \examples{
 \dontrun{
 board <- board_connect()

--- a/tests/testthat/_snaps/board_connect.md
+++ b/tests/testthat/_snaps/board_connect.md
@@ -30,7 +30,7 @@
     Code
       rsc_content_find(board, "marjory/test-partial")
     Condition
-      Error in `rsc_content_find_live()`:
+      Error in `rsc_content_find()`:
       ! Can't find pin named 'test-partial' with owner 'marjory'
 
 # can create and delete content
@@ -47,7 +47,7 @@
     Code
       rsc_content_delete(board, "test-1")
     Condition
-      Error in `rsc_content_find_live()`:
+      Error in `rsc_content_find()`:
       ! Can't find pin called "test-1"
       i Use `pin_list()` to see all available pins in this board
 


### PR DESCRIPTION
In #667 we moved from caches saved to disk to environment caches, but this still causes problems that are very confusing and hard to reason about, as @ryjohnson09 demonstrates in #789. I would like to propose we just throw this whole idea away; my opinion is that these Connect user and content caches are not gaining us much (especially now that they are only environment caches) and when things go wrong, it's pretty horrible.