### PR TITLE
Add new `urls` to metadata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 * Removed content and user caches for Connect altogether. Now, we look up 
   usernames and content on the Connect server every time (#793).
 
+* Added new `urls` item to metadata for a pin (#795).
+
 # pins 1.2.2
 
 * Fixed how dots are checked in `pin_write()` to make user-facing messages more 

--- a/R/board_connect_bundle.R
+++ b/R/board_connect_bundle.R
@@ -60,6 +60,8 @@ rsc_bundle_preview_index <- function(board, name, x, metadata) {
     pin_files = paste0("<a href=\"", metadata$file, "\">", metadata$file, "</a>", collapse = ", "),
     data_preview = jsonlite::toJSON(data_preview, auto_unbox = TRUE),
     data_preview_style = if (is.data.frame(x)) "" else "display:none",
+    urls = paste0("<a href=\"", metadata$urls, "\">", metadata$urls, "</a>", collapse = ", "),
+    url_preview_style = if (!is.null(metadata$urls)) "" else "display:none",
     pin_name = paste0(owner, "/", name$name),
     pin_metadata = list(
       as_yaml = yaml::as.yaml(metadata),

--- a/R/meta.R
+++ b/R/meta.R
@@ -36,7 +36,8 @@ standard_meta <- function(paths,
                           type,
                           title = NULL,
                           description = NULL,
-                          tags = NULL) {
+                          tags = NULL,
+                          urls = NULL) {
   list(
     file = fs::path_file(paths),
     file_size = as.integer(fs::file_size(paths)),
@@ -45,6 +46,7 @@ standard_meta <- function(paths,
     title = title,
     description = description,
     tags = if (is.null(tags)) tags else as.list(tags),
+    urls = if (is.null(urls)) urls else as.list(urls),
     created = format(Sys.time(), "%Y%m%dT%H%M%SZ", tz = "UTC"),
     api_version = 1L
   )

--- a/R/pin-meta.R
+++ b/R/pin-meta.R
@@ -12,6 +12,7 @@
 #'   * `$title` - pin title
 #'   * `$description` - pin description
 #'   * `$tags` - pin tags
+#'   * `$urls` - URLs for more info on pin
 #'   * `$created` - date this (version of the pin) was created
 #'   * `$api_version` - API version used by pin
 #'
@@ -97,12 +98,13 @@ empty_local_meta <- local_meta(x = NULL, name = NULL, dir = NULL)
 
 test_api_meta <- function(board) {
   testthat::test_that("can round-trip pin metadata", {
-    name <- local_pin(board, 1, title = "title", description = "desc", metadata = list(a = "a"), tags = c("tag1", "tag2"))
+    name <- local_pin(board, 1, title = "title", description = "desc", metadata = list(a = "a"), tags = c("tag1", "tag2"), urls = c("https://posit.co/"))
     meta <- pin_meta(board, name)
     testthat::expect_equal(meta$name, name)
     testthat::expect_equal(meta$title, "title")
     testthat::expect_equal(meta$description, "desc")
     testthat::expect_equal(meta$tags, c("tag1", "tag2"))
+    testthat::expect_equal(meta$urls, c("https://posit.co/"))
     testthat::expect_equal(meta$user$a, "a")
   })
 
@@ -132,6 +134,9 @@ test_api_meta <- function(board) {
   testthat::test_that("metadata checking functions give correct errors", {
     testthat::expect_snapshot_error(
       local_pin(board, 1, title = "title", tags = list(a = "a"))
+    )
+    testthat::expect_snapshot_error(
+      local_pin(board, 1, title = "title", urls = list(a = "a"))
     )
     testthat::expect_snapshot_error(
       local_pin(board, 1, title = "title", metadata = c("tag1", "tag2"))

--- a/R/pin-meta.R
+++ b/R/pin-meta.R
@@ -98,7 +98,7 @@ empty_local_meta <- local_meta(x = NULL, name = NULL, dir = NULL)
 
 test_api_meta <- function(board) {
   testthat::test_that("can round-trip pin metadata", {
-    name <- local_pin(board, 1, title = "title", description = "desc", metadata = list(a = "a"), tags = c("tag1", "tag2"), urls = c("https://posit.co/"))
+    name <- local_pin(board, 1, title = "title", description = "desc", metadata = list(a = "a"), tags = c("tag1", "tag2"), urls = "https://posit.co/")
     meta <- pin_meta(board, name)
     testthat::expect_equal(meta$name, name)
     testthat::expect_equal(meta$title, "title")

--- a/R/pin-meta.R
+++ b/R/pin-meta.R
@@ -104,7 +104,7 @@ test_api_meta <- function(board) {
     testthat::expect_equal(meta$title, "title")
     testthat::expect_equal(meta$description, "desc")
     testthat::expect_equal(meta$tags, c("tag1", "tag2"))
-    testthat::expect_equal(meta$urls, c("https://posit.co/"))
+    testthat::expect_equal(meta$urls, "https://posit.co/")
     testthat::expect_equal(meta$user$a, "a")
   })
 

--- a/R/pin-meta.R
+++ b/R/pin-meta.R
@@ -131,18 +131,6 @@ test_api_meta <- function(board) {
     )
   })
 
-  testthat::test_that("metadata checking functions give correct errors", {
-    testthat::expect_snapshot_error(
-      local_pin(board, 1, title = "title", tags = list(a = "a"))
-    )
-    testthat::expect_snapshot_error(
-      local_pin(board, 1, title = "title", urls = list(a = "a"))
-    )
-    testthat::expect_snapshot_error(
-      local_pin(board, 1, title = "title", metadata = c("tag1", "tag2"))
-    )
-  })
-
   testthat::test_that("pin_meta() returns pins_meta object", {
     name <- local_pin(board, 1)
 

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -64,6 +64,8 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #'   use the default for `board`
 #' @param tags A character vector of tags for the pin; most important for
 #'   discoverability on shared boards.
+#' @param urls A character vector of URLs for more info on the pin, such as a
+#'   link to a wiki or other documentation.
 #' @param force_identical_write Store the pin even if the pin contents are
 #'   identical to the last version (compared using the hash). Only the pin
 #'   contents are compared, not the pin metadata. Defaults to `FALSE`.
@@ -78,6 +80,7 @@ pin_write <- function(board, x,
                       metadata = NULL,
                       versioned = NULL,
                       tags = NULL,
+                      urls = NULL,
                       force_identical_write = FALSE) {
   check_board(board, "pin_write", "pin")
   dots <- list2(...)
@@ -96,6 +99,7 @@ pin_write <- function(board, x,
   }
   check_metadata(metadata)
   check_character(tags, allow_null = TRUE)
+  check_character(urls, allow_null = TRUE)
   if (!is_string(name)) {
     abort("`name` must be a string")
   }
@@ -114,7 +118,8 @@ pin_write <- function(board, x,
     type = type,
     title = title %||% default_title(name, data = x),
     description = description,
-    tags = tags
+    tags = tags,
+    urls = urls
   )
   meta$user <- metadata
 

--- a/inst/preview/index.html
+++ b/inst/preview/index.html
@@ -44,14 +44,12 @@
          <pre>{{{as_yaml}}}</pre>
        </details>
        {{/pin_metadata}}
-     </section>
-
-    {#urls}
-    <section>
-      <h3>Learn more about this pin at:</h3>
-      <p>{{{.}}}</p>
     </section>
-    {/urls}
+
+    <section style="{{url_preview_style}}">
+      <h3>Learn more about this pin at:</h3>
+      <p>{{{urls}}}</p>
+    </section>
 
     <section>
     <h3>R Code</h3>

--- a/inst/preview/index.html
+++ b/inst/preview/index.html
@@ -46,10 +46,12 @@
        {{/pin_metadata}}
      </section>
 
-    <section style="{{url_preview_style}}">
+    {#urls}
+    <section>
       <h3>Learn more about this pin at:</h3>
-      <p>{{{urls}}}</p>
+      <p>{{{.}}}</p>
     </section>
+    {/urls}
 
     <section>
     <h3>R Code</h3>

--- a/inst/preview/index.html
+++ b/inst/preview/index.html
@@ -46,6 +46,11 @@
        {{/pin_metadata}}
      </section>
 
+    <section style="{{url_preview_style}}">
+      <h3>Learn more about this pin at:</h3>
+      <p>{{{urls}}}</p>
+    </section>
+
     <section>
     <h3>R Code</h3>
       <pre id="pin-r" class="pin-code"><code class="r">library(pins)

--- a/man/pin_meta.Rd
+++ b/man/pin_meta.Rd
@@ -33,6 +33,7 @@ Pin metadata comes from three sources:
 \item \verb{$title} - pin title
 \item \verb{$description} - pin description
 \item \verb{$tags} - pin tags
+\item \verb{$urls} - URLs for more info on pin
 \item \verb{$created} - date this (version of the pin) was created
 \item \verb{$api_version} - API version used by pin
 }

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -18,6 +18,7 @@ pin_write(
   metadata = NULL,
   versioned = NULL,
   tags = NULL,
+  urls = NULL,
   force_identical_write = FALSE
 )
 }
@@ -59,6 +60,9 @@ use the default for \code{board}}
 
 \item{tags}{A character vector of tags for the pin; most important for
 discoverability on shared boards.}
+
+\item{urls}{A character vector of URLs for more info on the pin, such as a
+link to a wiki or other documentation.}
 
 \item{force_identical_write}{Store the pin even if the pin contents are
 identical to the last version (compared using the hash). Only the pin

--- a/tests/testthat/_snaps/board_azure_adls2.md
+++ b/tests/testthat/_snaps/board_azure_adls2.md
@@ -12,30 +12,6 @@
     Output
       [1] "AzureStor"
 
-# metadata checking functions give correct errors
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
----
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
 # can deparse
 
     Code

--- a/tests/testthat/_snaps/board_azure_adls2.md
+++ b/tests/testthat/_snaps/board_azure_adls2.md
@@ -18,11 +18,19 @@
 
 ---
 
+    `urls` must be a character vector or `NULL`, not a list.
+
+---
+
     `metadata` must be a list or `NULL`, not a character vector.
 
 ---
 
     `tags` must be a character vector or `NULL`, not a list.
+
+---
+
+    `urls` must be a character vector or `NULL`, not a list.
 
 ---
 

--- a/tests/testthat/_snaps/board_azure_blob.md
+++ b/tests/testthat/_snaps/board_azure_blob.md
@@ -12,30 +12,6 @@
     Output
       [1] "AzureStor"
 
-# metadata checking functions give correct errors
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
----
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
 # can deparse
 
     Code

--- a/tests/testthat/_snaps/board_azure_blob.md
+++ b/tests/testthat/_snaps/board_azure_blob.md
@@ -18,11 +18,19 @@
 
 ---
 
+    `urls` must be a character vector or `NULL`, not a list.
+
+---
+
     `metadata` must be a list or `NULL`, not a character vector.
 
 ---
 
     `tags` must be a character vector or `NULL`, not a list.
+
+---
+
+    `urls` must be a character vector or `NULL`, not a list.
 
 ---
 

--- a/tests/testthat/_snaps/board_azure_file.md
+++ b/tests/testthat/_snaps/board_azure_file.md
@@ -12,30 +12,6 @@
     Output
       [1] "AzureStor"
 
-# metadata checking functions give correct errors
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
----
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
 # can deparse
 
     Code

--- a/tests/testthat/_snaps/board_azure_file.md
+++ b/tests/testthat/_snaps/board_azure_file.md
@@ -18,11 +18,19 @@
 
 ---
 
+    `urls` must be a character vector or `NULL`, not a list.
+
+---
+
     `metadata` must be a list or `NULL`, not a character vector.
 
 ---
 
     `tags` must be a character vector or `NULL`, not a list.
+
+---
+
+    `urls` must be a character vector or `NULL`, not a list.
 
 ---
 

--- a/tests/testthat/_snaps/board_connect.md
+++ b/tests/testthat/_snaps/board_connect.md
@@ -11,6 +11,10 @@
 
 ---
 
+    `urls` must be a character vector or `NULL`, not a list.
+
+---
+
     `metadata` must be a list or `NULL`, not a character vector.
 
 # get useful error for rebranding

--- a/tests/testthat/_snaps/board_connect.md
+++ b/tests/testthat/_snaps/board_connect.md
@@ -5,18 +5,6 @@
     Output
       [1] "rsconnect"
 
-# metadata checking functions give correct errors
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
 # get useful error for rebranding
 
     `board_rsconnect()` was deprecated in pins 1.1.0.

--- a/tests/testthat/_snaps/board_connect_bundle.md
+++ b/tests/testthat/_snaps/board_connect_bundle.md
@@ -38,7 +38,7 @@
              <b>Format:</b> rds &bull;
              <b>API:</b> v1.0
            </p>
-           <p></p>
+           <p>Some simple data to test with</p>
            <p>Download data: <a href="test.csv">test.csv</a></p>
            <details>
              <summary>Raw metadata</summary>
@@ -47,7 +47,10 @@
     pin_hash: 77fee172a9275a62
     type: rds
     title: 'test: a pinned 2 x 2 data frame'
-    desctiption: Some simple data to test with
+    description: Some simple data to test with
+    urls:
+    - https://posit.co/
+    - https://www.tidyverse.org/
     created: 20211111T113956Z
     api_version: '1.0'
     user:
@@ -55,6 +58,11 @@
     </pre>
            </details>
          </section>
+    
+        <section style="">
+          <h3>Learn more about this pin at:</h3>
+          <p><a href="https://posit.co/">https://posit.co/</a>, <a href="https://www.tidyverse.org/">https://www.tidyverse.org/</a></p>
+        </section>
     
         <section>
         <h3>R Code</h3>

--- a/tests/testthat/_snaps/board_connect_bundle.md
+++ b/tests/testthat/_snaps/board_connect_bundle.md
@@ -57,7 +57,7 @@
       my_meta: User defined metadata
     </pre>
            </details>
-         </section>
+        </section>
     
         <section style="">
           <h3>Learn more about this pin at:</h3>

--- a/tests/testthat/_snaps/board_folder.md
+++ b/tests/testthat/_snaps/board_folder.md
@@ -5,18 +5,6 @@
     Output
       character(0)
 
-# metadata checking functions give correct errors
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
 # has useful print method
 
     Code

--- a/tests/testthat/_snaps/board_folder.md
+++ b/tests/testthat/_snaps/board_folder.md
@@ -11,6 +11,10 @@
 
 ---
 
+    `urls` must be a character vector or `NULL`, not a list.
+
+---
+
     `metadata` must be a list or `NULL`, not a character vector.
 
 # has useful print method

--- a/tests/testthat/_snaps/board_gcs.md
+++ b/tests/testthat/_snaps/board_gcs.md
@@ -18,6 +18,10 @@
 
 ---
 
+    `urls` must be a character vector or `NULL`, not a list.
+
+---
+
     `metadata` must be a list or `NULL`, not a character vector.
 
 # can deparse

--- a/tests/testthat/_snaps/board_gcs.md
+++ b/tests/testthat/_snaps/board_gcs.md
@@ -12,18 +12,6 @@
     Output
       [1] "googleCloudStorageR"
 
-# metadata checking functions give correct errors
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
 # can deparse
 
     Code

--- a/tests/testthat/_snaps/board_gdrive.md
+++ b/tests/testthat/_snaps/board_gdrive.md
@@ -11,5 +11,9 @@
 
 ---
 
+    `urls` must be a character vector or `NULL`, not a list.
+
+---
+
     `metadata` must be a list or `NULL`, not a character vector.
 

--- a/tests/testthat/_snaps/board_gdrive.md
+++ b/tests/testthat/_snaps/board_gdrive.md
@@ -5,15 +5,3 @@
     Output
       [1] "googledrive"
 
-# metadata checking functions give correct errors
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-

--- a/tests/testthat/_snaps/board_s3.md
+++ b/tests/testthat/_snaps/board_s3.md
@@ -18,6 +18,10 @@
 
 ---
 
+    `urls` must be a character vector or `NULL`, not a list.
+
+---
+
     `metadata` must be a list or `NULL`, not a character vector.
 
 # can deparse

--- a/tests/testthat/_snaps/board_s3.md
+++ b/tests/testthat/_snaps/board_s3.md
@@ -12,18 +12,6 @@
     Output
       [1] "paws.storage"
 
-# metadata checking functions give correct errors
-
-    `tags` must be a character vector or `NULL`, not a list.
-
----
-
-    `urls` must be a character vector or `NULL`, not a list.
-
----
-
-    `metadata` must be a list or `NULL`, not a character vector.
-
 # can deparse
 
     Code

--- a/tests/testthat/_snaps/meta.md
+++ b/tests/testthat/_snaps/meta.md
@@ -1,6 +1,6 @@
 # standard metadata is useful
 
-    List of 9
+    List of 10
      $ file       : chr "df.rds"
      $ file_size  : int 200
      $ pin_hash   : chr "db696042be80dbb4"
@@ -8,6 +8,7 @@
      $ title      : chr "title"
      $ description: NULL
      $ tags       : NULL
+     $ urls       : NULL
      $ created    : chr "<TODAY>"
      $ api_version: int 1
 

--- a/tests/testthat/_snaps/pin-read-write.md
+++ b/tests/testthat/_snaps/pin-read-write.md
@@ -34,6 +34,21 @@
     Condition
       Error in `pin_write()`:
       ! `metadata` must be a list or `NULL`, not the number 1.
+    Code
+      pin_write(board, mtcars, title = "title", tags = list(a = "a"))
+    Condition
+      Error in `pin_write()`:
+      ! `tags` must be a character vector or `NULL`, not a list.
+    Code
+      pin_write(board, mtcars, title = "title", urls = list(a = "a"))
+    Condition
+      Error in `pin_write()`:
+      ! `urls` must be a character vector or `NULL`, not a list.
+    Code
+      pin_write(board, mtcars, title = "title", metadata = c("tag1", "tag2"))
+    Condition
+      Error in `pin_write()`:
+      ! `metadata` must be a list or `NULL`, not a character vector.
 
 # pin_write() noisily generates name and type
 

--- a/tests/testthat/test-board_connect_bundle.R
+++ b/tests/testthat/test-board_connect_bundle.R
@@ -28,7 +28,8 @@ test_that("generates index files", {
     pin_hash = "77fee172a9275a62",
     type = "rds",
     title = "test: a pinned 2 x 2 data frame",
-    desctiption = "Some simple data to test with",
+    description = "Some simple data to test with",
+    urls = c("https://posit.co/", "https://www.tidyverse.org/"),
     created = "20211111T113956Z",
     api_version = "1.0",
     user = list(my_meta = "User defined metadata")

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -44,6 +44,9 @@ test_that("useful errors on bad inputs", {
     pin_write(board, mtcars, name = "mtcars", "json")
     pin_write(board, mtcars, name = "mtcars", type = "froopy-loops")
     pin_write(board, mtcars, name = "mtcars", metadata = 1)
+    pin_write(board, mtcars, title = "title", tags = list(a = "a"))
+    pin_write(board, mtcars, title = "title", urls = list(a = "a"))
+    pin_write(board, mtcars, title = "title", metadata = c("tag1", "tag2"))
   })
 })
 


### PR DESCRIPTION
One thing we thought about when listening to JD Long's keynote talk at posit::conf last month was the value of making sure it is as easy as possible connect datasets to documentation. This PR is inspired by those thoughts and adds a new option for storing `urls` (a character vector) along with your dataset.

It's used like this:

``` r
library(pins)

b <- board_connect()
#> Connecting to Posit Connect 2023.07.0 at <https://colorado.posit.co/rsc>
b |> pin_write(
    c(200, 404, 503),
    "http-code-numbers",
    urls = c("https://httbey.com/", "https://http.cat/"),
    force_identical_write = TRUE
)
#> Guessing `type = 'rds'`
#> Writing to pin 'julia.silge/http-code-numbers'
```

<sup>Created on 2023-10-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

I added the URLs to the Connect preview, which you can see here:
https://colorado.posit.co/rsc/httpbey-pin/

Any thoughts on a better way to present that?