### PR TITLE
Add Python code to Connect preview HTML

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pins (development version)
 
+* Added example Python code to pin previews for Posit Connect (#806).
+
 # pins 1.3.0
 
 ## Breaking changes

--- a/R/board_connect_bundle.R
+++ b/R/board_connect_bundle.R
@@ -62,6 +62,7 @@ rsc_bundle_preview_index <- function(board, name, x, metadata) {
     data_preview_style = if (is.data.frame(x)) "" else "display:none",
     urls = paste0("<a href=\"", metadata$urls, "\">", metadata$urls, "</a>", collapse = ", "),
     url_preview_style = if (!is.null(metadata$urls)) "" else "display:none",
+    show_python_style = if (metadata$type != "rds") "" else "display:none",
     pin_name = paste0(owner, "/", name$name),
     pin_metadata = list(
       as_yaml = yaml::as.yaml(metadata),

--- a/R/board_connect_bundle.R
+++ b/R/board_connect_bundle.R
@@ -62,7 +62,7 @@ rsc_bundle_preview_index <- function(board, name, x, metadata) {
     data_preview_style = if (is.data.frame(x)) "" else "display:none",
     urls = paste0("<a href=\"", metadata$urls, "\">", metadata$urls, "</a>", collapse = ", "),
     url_preview_style = if (!is.null(metadata$urls)) "" else "display:none",
-    show_python_style = if (!metadata$type %in% c("rds", "qs")) "" else "display:none",
+    show_python_style = if (metadata$type %in% c("rds", "qs")) "display:none" else "",
     pin_name = paste0(owner, "/", name$name),
     pin_metadata = list(
       as_yaml = yaml::as.yaml(metadata),

--- a/R/board_connect_bundle.R
+++ b/R/board_connect_bundle.R
@@ -62,7 +62,7 @@ rsc_bundle_preview_index <- function(board, name, x, metadata) {
     data_preview_style = if (is.data.frame(x)) "" else "display:none",
     urls = paste0("<a href=\"", metadata$urls, "\">", metadata$urls, "</a>", collapse = ", "),
     url_preview_style = if (!is.null(metadata$urls)) "" else "display:none",
-    show_python_style = if (metadata$type != "rds") "" else "display:none",
+    show_python_style = if (!metadata$type %in% c("rds", "qs")) "" else "display:none",
     pin_name = paste0(owner, "/", name$name),
     pin_metadata = list(
       as_yaml = yaml::as.yaml(metadata),

--- a/inst/preview/index.html
+++ b/inst/preview/index.html
@@ -62,10 +62,13 @@ pin_read(board, "{{pin_name}}")</code></pre>
         hljs.initHighlightingOnLoad();
       </script>
     </section>
-    
+
     <section style="{{show_python_style}}">
       <h3>Python Code</h3>
         <pre id="pin-python" class="pin-code"><code class="python">import pins
+from dotenv import load_dotenv
+load_dotenv()
+
 board = pins.board_connect()
 board.pin_read(board, "{{pin_name}}")</code></pre>
     </section>

--- a/inst/preview/index.html
+++ b/inst/preview/index.html
@@ -53,7 +53,7 @@
 
     <section>
       <h3>R Code</h3>
-        <pre id="pin-r" class="pin-code-r"><code class="r">library(pins)
+        <pre id="pin-r" class="pin-code"><code class="r">library(pins)
 board <- {{{board_deparse}}}
 pin_read(board, "{{pin_name}}")</code></pre>
       <script type="text/javascript">
@@ -65,7 +65,7 @@ pin_read(board, "{{pin_name}}")</code></pre>
     
     <section style="{{show_python_style}}">
       <h3>Python Code</h3>
-        <pre id="pin-python" class="pin-code-python"><code class="python">import pins
+        <pre id="pin-python" class="pin-code"><code class="python">import pins
 board = pins.board_connect()
 board.pin_read(board, "{{pin_name}}")</code></pre>
     </section>

--- a/inst/preview/index.html
+++ b/inst/preview/index.html
@@ -33,7 +33,7 @@
        <h3>{{{pin_name}}}</h3>
        {{#pin_metadata}}
        <p>
-         {{#date}}<b>Last updated:</b> {{{.}}} &bull;{{/date}}
+         {{#date}}<b>Last updated from R:</b> {{{.}}} &bull;{{/date}}
          <b>Format:</b> {{{format}}} &bull;
          <b>API:</b> v{{{api_version}}}
        </p>
@@ -52,14 +52,22 @@
     </section>
 
     <section>
-    <h3>R Code</h3>
-      <pre id="pin-r" class="pin-code"><code class="r">library(pins)
+      <h3>R Code</h3>
+        <pre id="pin-r" class="pin-code-r"><code class="r">library(pins)
 board <- {{{board_deparse}}}
 pin_read(board, "{{pin_name}}")</code></pre>
-    <script type="text/javascript">
-      hljs.registerLanguage("r", highlight_r);
-      hljs.initHighlightingOnLoad();
-    </script>
+      <script type="text/javascript">
+        hljs.registerLanguage("r", highlight_r);
+        hljs.registerLanguage("python", highlight_python);
+        hljs.initHighlightingOnLoad();
+      </script>
+    </section>
+    
+    <section style="{{show_python_style}}">
+      <h3>Python Code</h3>
+        <pre id="pin-python" class="pin-code-python"><code class="python">import pins
+board = pins.board_connect()
+board.pin_read(board, "{{pin_name}}")</code></pre>
     </section>
 
     <section style="{{data_preview_style}}">

--- a/tests/testthat/_snaps/board_connect_bundle.md
+++ b/tests/testthat/_snaps/board_connect_bundle.md
@@ -66,7 +66,7 @@
     
         <section>
           <h3>R Code</h3>
-            <pre id="pin-r" class="pin-code-r"><code class="r">library(pins)
+            <pre id="pin-r" class="pin-code"><code class="r">library(pins)
     board <- board_connect(auth = "envvar")
     pin_read(board, "TEST/test")</code></pre>
           <script type="text/javascript">
@@ -78,7 +78,7 @@
         
         <section style="display:none">
           <h3>Python Code</h3>
-            <pre id="pin-python" class="pin-code-python"><code class="python">import pins
+            <pre id="pin-python" class="pin-code"><code class="python">import pins
     board = pins.board_connect()
     board.pin_read(board, "TEST/test")</code></pre>
         </section>

--- a/tests/testthat/_snaps/board_connect_bundle.md
+++ b/tests/testthat/_snaps/board_connect_bundle.md
@@ -75,10 +75,13 @@
             hljs.initHighlightingOnLoad();
           </script>
         </section>
-        
+    
         <section style="display:none">
           <h3>Python Code</h3>
             <pre id="pin-python" class="pin-code"><code class="python">import pins
+    from dotenv import load_dotenv
+    load_dotenv()
+    
     board = pins.board_connect()
     board.pin_read(board, "TEST/test")</code></pre>
         </section>

--- a/tests/testthat/_snaps/board_connect_bundle.md
+++ b/tests/testthat/_snaps/board_connect_bundle.md
@@ -34,7 +34,7 @@
         <section>
            <h3>TEST/test</h3>
            <p>
-             <b>Last updated:</b> 2021-11-11 11:39:56 &bull;
+             <b>Last updated from R:</b> 2021-11-11 11:39:56 &bull;
              <b>Format:</b> rds &bull;
              <b>API:</b> v1.0
            </p>
@@ -65,14 +65,22 @@
         </section>
     
         <section>
-        <h3>R Code</h3>
-          <pre id="pin-r" class="pin-code"><code class="r">library(pins)
+          <h3>R Code</h3>
+            <pre id="pin-r" class="pin-code-r"><code class="r">library(pins)
     board <- board_connect(auth = "envvar")
     pin_read(board, "TEST/test")</code></pre>
-        <script type="text/javascript">
-          hljs.registerLanguage("r", highlight_r);
-          hljs.initHighlightingOnLoad();
-        </script>
+          <script type="text/javascript">
+            hljs.registerLanguage("r", highlight_r);
+            hljs.registerLanguage("python", highlight_python);
+            hljs.initHighlightingOnLoad();
+          </script>
+        </section>
+        
+        <section style="display:none">
+          <h3>Python Code</h3>
+            <pre id="pin-python" class="pin-code-python"><code class="python">import pins
+    board = pins.board_connect()
+    board.pin_read(board, "TEST/test")</code></pre>
         </section>
     
         <section style="">

--- a/tests/testthat/test-board_connect_bundle.R
+++ b/tests/testthat/test-board_connect_bundle.R
@@ -5,10 +5,10 @@ test_that("bundle contains expected files", {
   saveRDS(df, fs::path(path, "test.rds"))
 
   board <- list(account = "TEST", server_name = "example.com")
-  metadata <- list(file = "test.rds")
+  metadata <- list(file = "test.rds", type = "rds")
   class(board) <- c("pins_board_connect", "pins_board")
 
-  out <- rsc_bundle(board, "test", fs::path(path, "test.rds"), list(), df)
+  out <- rsc_bundle(board, "test", fs::path(path, "test.rds"), metadata, df)
 
   files <- fs::dir_ls(out)
   files <- files[!fs::is_dir(files)]


### PR DESCRIPTION
Addresses #796

We discussed a button to switch between the R / Python code, but we need to _not_ show the code at all for `.rds` pins so I think it's better to just do it with another `<section>`. This is my current proposal:

![Screenshot 2023-11-09 at 6 07 29 PM](https://github.com/rstudio/pins-r/assets/12505835/ba69717d-5a5b-4cba-b749-be113951634c)


You can see a [published version here](https://colorado.posit.co/rsc/content/a444e2ba-1d26-4945-99ce-7d184a82385d).
