### PR TITLE
Improve error message for problems with URLs

### DIFF
--- a/R/board_connect_url.R
+++ b/R/board_connect_url.R
@@ -7,9 +7,9 @@
 #' `board_connect_url()` is read only, and does not support versioning.
 #'
 #' @param vanity_urls A named character vector of
-#'   [Connect vanity URLs](https://docs.posit.co/connect/user/content-settings/#custom-url).
-#'   This board is read only, and the best way to write to a pin on Connect is
-#'   [board_connect()].
+#'   [Connect vanity URLs](https://docs.posit.co/connect/user/content-settings/#custom-url),
+#'   including trailing slash. This board is read only, and the best way to write to a pin 
+#'   on Connect is [board_connect()].
 #' @family boards
 #' @inheritParams new_board
 #' @inheritParams board_url

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -226,9 +226,10 @@ object_read <- function(meta) {
       joblib = abort("'joblib' pins not supported in R"),
       csv = utils::read.csv(path),
       qs = read_qs(path),
-      file = abort(c(
-        "Pin does not declare file type so can't be automatically read",
-        i = "Retrieve uploaded paths with `pin_download()`"
+      file = cli_abort(c(
+        "Cannot automatically read pin:",
+        "*" = "Is your pin specified as a full path? Retrieve it with {.code pin_download()}",
+        "*" = "Is your pin specified via a URL that is {.emph not} a full path, such as a Posit Connect vanity URL? Remember to include a trailing slash {.code /}"
       ))
     )
   } else {

--- a/man/board_connect_url.Rd
+++ b/man/board_connect_url.Rd
@@ -16,9 +16,9 @@ connect_auth_headers(key = Sys.getenv("CONNECT_API_KEY"))
 }
 \arguments{
 \item{vanity_urls}{A named character vector of
-\href{https://docs.posit.co/connect/user/content-settings/#custom-url}{Connect vanity URLs}.
-This board is read only, and the best way to write to a pin on Connect is
-\code{\link[=board_connect]{board_connect()}}.}
+\href{https://docs.posit.co/connect/user/content-settings/#custom-url}{Connect vanity URLs},
+including trailing slash. This board is read only, and the best way to write to a pin
+on Connect is \code{\link[=board_connect]{board_connect()}}.}
 
 \item{cache}{Cache path. Every board requires a local cache to avoid
 downloading files multiple times. The default stores in a standard

--- a/tests/testthat/_snaps/board_url.md
+++ b/tests/testthat/_snaps/board_url.md
@@ -7,8 +7,9 @@
 
 # raw pins can only be downloaded
 
-    Pin does not declare file type so can't be automatically read
-    i Retrieve uploaded paths with `pin_download()`
+    Cannot automatically read pin:
+    * Is your pin specified as a full path? Retrieve it with `pin_download()`
+    * Is your pin specified via a URL that is not a full path, such as a Posit Connect vanity URL? Remember to include a trailing slash `/`
 
 # useful errors for unsupported methods
 

--- a/tests/testthat/_snaps/pin-read-write.md
+++ b/tests/testthat/_snaps/pin-read-write.md
@@ -4,8 +4,9 @@
       pin_read(board, "test")
     Condition
       Error in `object_read()`:
-      ! Pin does not declare file type so can't be automatically read
-      i Retrieve uploaded paths with `pin_download()`
+      ! Cannot automatically read pin:
+      * Is your pin specified as a full path? Retrieve it with `pin_download()`
+      * Is your pin specified via a URL that is not a full path, such as a Posit Connect vanity URL? Remember to include a trailing slash `/`
 
 # useful errors on bad inputs
 


### PR DESCRIPTION
Closes #810 

We now see a message like this when we end up in a bad URL situation, such as trying `pin_read()` on a full path or forgetting a trailing slash for a vanity URL:

``` r
library(pins)
board <- board_connect_url(c(
  numbers = "https://colorado.posit.co/rsc/some-nice-numbers"
))
board |> pin_read("numbers")
#> Error in `object_read()`:
#> ! Cannot automatically read pin:
#> • Is your pin specified as a full path? Retrieve it with `pin_download()`
#> • Is your pin specified via a URL that is not a full path, such as a Posit
#>   Connect vanity URL? Remember to include a trailing slash `/`
#> Backtrace:
#>     ▆
#>  1. └─pins::pin_read(board, "numbers")
#>  2.   └─pins:::object_read(meta)
#>  3.     └─cli::cli_abort(...)
#>  4.       └─rlang::abort(...)
```

<sup>Created on 2023-11-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

@slodge do you have any feedback on this?