### PR TITLE
Fix folder creation by `gdrive_mkdir()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Fixed a bug in how pins with the same name but different owners on Posit Connect were identified (#808).
 
+* Fixed a bug in handling folders with duplicate names for Google Drive (#819, @UchidaMizuki)
+
 # pins 1.3.0
 
 ## Breaking changes

--- a/R/board_gdrive.R
+++ b/R/board_gdrive.R
@@ -146,11 +146,8 @@ pin_store.pins_board_gdrive <- function(board, name, paths, metadata,
   check_pin_name(name)
   version <- version_setup(board, name, version_name(metadata), versioned = versioned)
 
-  gdrive_mkdir(board$dribble$name, name)
-  gdrive_mkdir(fs::path(board$dribble$name, name), version)
-
-  version_dir <- fs::path(name, version)
-  version_dir_dribble = googledrive::as_dribble(version_dir)
+  dir_dribble <- gdrive_mkdir(board$dribble, name)
+  version_dir_dribble <- gdrive_mkdir(dir_dribble, version)
 
   # Upload metadata
   temp_file <- withr::local_tempfile()
@@ -211,10 +208,11 @@ gdrive_download <- function(board, key) {
   path
 }
 
-gdrive_mkdir <- function(dir, name) {
-  dribble <- googledrive::as_dribble(fs::path(dir, name))
-  if (googledrive::no_file(dribble) || !googledrive::is_folder(dribble)) {
-    googledrive::drive_mkdir(name, dir, overwrite = FALSE)
+gdrive_mkdir <- function(dribble, name) {
+  dir_dribble <- googledrive::drive_ls(dribble, type = "folder")
+  dir_dribble <- dir_dribble[dir_dribble$name == name,]
+  if (googledrive::no_file(dir_dribble)) {
+    dir_dribble <- googledrive::drive_mkdir(name, dribble, overwrite = FALSE)
   }
-  invisible()
+  invisible(dir_dribble)
 }


### PR DESCRIPTION
Closes #818.

This PR changes to use `drive_id` instead of folder `name` when creating folders in gdrive.
This change resolves the issue of creating folders due to duplicate folder names.

This change resolves #818 locally.
``` r
library(pins)
library(googledrive)
drive_auth("uchidamizuki@vivaldi.net")

board <- board_gdrive(as_id("11wUPQi82qsXArmMeu3ENdUK_QvdU1rMv"))
board |> 
  pin_write(iris, "iris")
#> Guessing `type = 'rds'`
#> Creating new version '20240111T113330Z-d16b7'
#> Writing to pin 'iris'
```

<sup>Created on 2024-01-11 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
