### PR TITLE
Remove ellipsis dependency in favour of rlang

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,6 @@ Depends:
 Imports:
     cli,
     digest,
-    ellipsis,
     fs,
     generics,
     glue,

--- a/R/board.R
+++ b/R/board.R
@@ -150,7 +150,7 @@ board_cache_path <- function(name) {
 #' @export
 #' @inheritParams pin_read
 board_deparse <- function(board, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   UseMethod("board_deparse")
 }
 
@@ -246,7 +246,7 @@ make_manifest <- function(board) {
 #' @param manifest Contents to be written to the manifest file, as a list.
 #'
 write_board_manifest_yaml <- function(board, manifest, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   UseMethod("write_board_manifest_yaml")
 }
 

--- a/R/board_azure.R
+++ b/R/board_azure.R
@@ -222,7 +222,7 @@ write_board_manifest_yaml.pins_board_azure <- function(board, manifest, ...) {
 #' @rdname required_pkgs.pins_board
 #' @export
 required_pkgs.pins_board_azure <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
   "AzureStor"
 }
 

--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -364,7 +364,7 @@ board_deparse.pins_board_connect <- function(board, ...) {
 #' @rdname required_pkgs.pins_board
 #' @export
 required_pkgs.pins_board_connect <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
   "rsconnect"
 }
 

--- a/R/board_gcs.R
+++ b/R/board_gcs.R
@@ -168,7 +168,7 @@ pin_fetch.pins_board_gcs <- function(board, name, version = NULL, ...) {
 pin_store.pins_board_gcs <- function(board, name, paths, metadata,
                                      versioned = NULL, x = NULL, ...) {
   withr::local_options(list(googleAuthR.verbose = 4))
-  ellipsis::check_dots_used()
+  check_dots_used()
   check_pin_name(name)
   version <- version_setup(board, name, version_name(metadata), versioned = versioned)
   version_dir <- fs::path(name, version)
@@ -200,7 +200,7 @@ board_deparse.pins_board_gcs <- function(board, ...) {
 #' @rdname required_pkgs.pins_board
 #' @export
 required_pkgs.pins_board_gcs <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
   "googleCloudStorageR"
 }
 

--- a/R/board_gdrive.R
+++ b/R/board_gdrive.R
@@ -174,7 +174,7 @@ pin_store.pins_board_gdrive <- function(board, name, paths, metadata,
 #' @rdname required_pkgs.pins_board
 #' @export
 required_pkgs.pins_board_gdrive <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
   "googledrive"
 }
 

--- a/R/board_ms365.R
+++ b/R/board_ms365.R
@@ -226,7 +226,7 @@ write_board_manifest_yaml.pins_board_ms365 <- function(board, manifest, ...) {
 #' @rdname required_pkgs.pins_board
 #' @export
 required_pkgs.pins_board_ms365 <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
   "Microsoft365R"
 }
 

--- a/R/board_s3.R
+++ b/R/board_s3.R
@@ -248,7 +248,7 @@ pin_fetch.pins_board_s3 <- function(board, name, version = NULL, ...) {
 #' @export
 pin_store.pins_board_s3 <- function(board, name, paths, metadata,
                                     versioned = NULL, x = NULL, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   check_pin_name(name)
   version <- version_setup(board, name, version_name(metadata), versioned = versioned)
 
@@ -289,7 +289,7 @@ write_board_manifest_yaml.pins_board_s3 <- function(board, manifest, ...) {
 #' @rdname required_pkgs.pins_board
 #' @export
 required_pkgs.pins_board_s3 <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
   "paws.storage"
 }
 
@@ -320,7 +320,7 @@ s3_upload_yaml <- function(board, key, yaml, ...) {
 }
 
 s3_upload_file <- function(board, key, path, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   body <- readBin(path, "raw", file.size(path))
   board$svc$put_object(
     Bucket = board$bucket,

--- a/R/pin-delete.R
+++ b/R/pin-delete.R
@@ -15,7 +15,7 @@
 #' board %>% pin_delete(c("x", "y"))
 #' board %>% pin_list()
 pin_delete <- function(board, names, ...) {
-  ellipsis::check_dots_used(...)
+  check_dots_used()
   check_board(board, "pin_delete", "pin_remove")
   UseMethod("pin_delete")
 }

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -38,7 +38,7 @@
 #' # (Normally you'd specify the version with a string, but since the
 #' # version includes the date-time I can't do that in an example)
 pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   check_board(board, "pin_read", "pin_get")
 
   meta <- pin_fetch(board, name, version = version, ...)
@@ -134,7 +134,7 @@ pin_write <- function(board, x,
     }
   }
 
-  ellipsis::check_dots_used()
+  check_dots_used()
   name <- pin_store(board, name, path, meta, versioned = versioned, x = x, ...)
   pins_inform("Writing to pin '{name}'")
   invisible(name)

--- a/R/pin-store-fetch.R
+++ b/R/pin-store-fetch.R
@@ -13,7 +13,7 @@
 #' @keywords internal
 #' @inheritParams pin_read
 pin_fetch <- function(board, name, version = NULL, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   UseMethod("pin_fetch")
 }
 
@@ -21,6 +21,6 @@ pin_fetch <- function(board, name, version = NULL, ...) {
 #' @rdname pin_fetch
 #' @inherit pin_upload
 pin_store <- function(board, name, paths, metadata, versioned = NULL, x = NULL, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   UseMethod("pin_store")
 }

--- a/R/pin_exists.R
+++ b/R/pin_exists.R
@@ -3,7 +3,7 @@
 #' @inheritParams pin_read
 #' @export
 pin_exists <- function(board, name, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   UseMethod("pin_exists")
 }
 

--- a/R/pin_list.R
+++ b/R/pin_list.R
@@ -16,6 +16,6 @@
 #'
 #' board %>% pin_list()
 pin_list <- function(board, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   UseMethod("pin_list")
 }

--- a/R/pin_search.R
+++ b/R/pin_search.R
@@ -24,7 +24,7 @@
 #' board %>% pin_search("letters")
 pin_search <- function(board, search = NULL, ...) {
   check_board(board, "pin_search", "pin_find")
-  ellipsis::check_dots_used()
+  check_dots_used()
   UseMethod("pin_search")
 }
 

--- a/R/pin_versions.R
+++ b/R/pin_versions.R
@@ -32,7 +32,7 @@
 #' board %>% pin_versions_prune("df", days = 30)
 #' @export
 pin_versions <- function(board, name, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
 
   if (missing(name) && is.board(board)) {
     abort("Argument `name` is missing, with no default")
@@ -73,7 +73,7 @@ pin_versions.pins_board <- function(board, name, ...) {
 #' @rdname pin_versions
 #' @param version Version identifier.
 pin_version_delete <- function(board, name, version, ...) {
-  ellipsis::check_dots_used()
+  check_dots_used()
   UseMethod("pin_version_delete")
 }
 

--- a/R/required_pkgs.R
+++ b/R/required_pkgs.R
@@ -10,6 +10,6 @@
 #'
 #' @export
 required_pkgs.pins_board <- function(x, ...) {
-  ellipsis::check_dots_empty()
+  check_dots_empty()
   character(0)
 }


### PR DESCRIPTION
Since deprecated in version 1.0. https://rlang.r-lib.org/news/index.html#argument-intake-1-0-0

ellipsis imports rlang anyway