### PR TITLE
Some maintenance on GH actions

### DIFF
--- a/.github/workflows/lock.yaml
+++ b/.github/workflows/lock.yaml
@@ -8,23 +8,17 @@ jobs:
   lock:
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@v5
         with:
           github-token: ${{ github.token }}
-          issue-lock-inactive-days: '14'
-#          issue-exclude-labels: ''
-#          issue-lock-labels: 'outdated'
-          issue-lock-comment: >
+          issue-inactive-days: '14'
+          issue-comment: >
             This issue has been automatically locked. If you believe you have
             found a related problem, please file a new issue (with a reprex:
             <https://reprex.tidyverse.org>) and link to this issue.
           issue-lock-reason: ''
-          pr-lock-inactive-days: '14'
-#          pr-exclude-labels: 'wip'
-          pr-lock-labels: ''
-          pr-lock-comment: >
+          pr-inactive-days: '14'
+          pr-comment: >
             This pull request has been automatically locked. If you believe you
             have found a related problem, please file a new issue (with a reprex:
             <https://reprex.tidyverse.org>) and link to this issue.
-          pr-lock-reason: ''
-#          process-only: 'issues'

--- a/.github/workflows/posit-connect.yaml
+++ b/.github/workflows/posit-connect.yaml
@@ -14,10 +14,10 @@ jobs:
       RSC_LICENSE: ${{ secrets.RSC_LICENSE }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: run Connect
-        run: docker-compose up -d --build
+        run: docker compose up -d --build
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -59,5 +59,5 @@ jobs:
       - name: shutdown Posit Connect
         if: always()
         run: |
-          docker-compose down
+          docker compose down
 

--- a/.github/workflows/posit-connect.yaml
+++ b/.github/workflows/posit-connect.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: create Connect users
         run: |
           curl -s --retry 10 --retry-connrefused http://localhost:3939
-          docker-compose exec -T rsconnect bash < .github/setup-connect/add-users.sh
+          docker compose exec -T rsconnect bash < .github/setup-connect/add-users.sh
 
       - name: initialize Connect users
         shell: Rscript {0}

--- a/tests/testthat/test-board_url.R
+++ b/tests/testthat/test-board_url.R
@@ -1,5 +1,6 @@
 skip_if_not_installed("webfakes")
 skip_on_cran()
+skip_on_covr()
 
 httpbin <- local_httpbin_app()
 httpbin_port <- httpbin$get_port()


### PR DESCRIPTION
There are two changes here:

- Updating the lock GH action to use a more recent version which hopefully won't fail so much
- Skipping the webfakes tests on the test coverage action, since it currently fails