### PR TITLE
Fixed edge case where n_versions = 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Fixed a bug in handling folders with duplicate names for Google Drive (#819, @UchidaMizuki)
 
+* Fixed how previously deleted pin versions are detected (#838, @MichalLauer)
+
 # pins 1.3.0
 
 ## Breaking changes

--- a/R/pin_versions.R
+++ b/R/pin_versions.R
@@ -157,19 +157,22 @@ version_from_path <- function(x) {
 }
 
 version_setup <- function(board, name, new_version, versioned = NULL, call = caller_env()) {
+  
+  n_versions <- 0
   if (pin_exists(board, name)) {
     versions <- pin_versions(board, name)
-    old_version <- versions$version[[1]]
     n_versions <- nrow(versions)
-    if (old_version == new_version) {
-      cli::cli_abort(c(
-        "The new version {.val {new_version}} is the same as the most recent version.",
-        i = "Did you try to create a new version with the same timestamp as the last version?"
-      ),
-      call = call)
+    
+    if (n_versions > 0) {
+      old_version <- versions$version[[1]]
+      if (old_version == new_version) {
+        cli::cli_abort(c(
+          "The new version {.val {new_version}} is the same as the most recent version.",
+          i = "Did you try to create a new version with the same timestamp as the last version?"
+        ),
+        call = call)
+      }
     }
-  } else {
-    n_versions <- 0
   }
 
   versioned <- versioned %||% if (n_versions > 1) TRUE else board$versioned

--- a/R/pin_versions.R
+++ b/R/pin_versions.R
@@ -159,6 +159,7 @@ version_from_path <- function(x) {
 version_setup <- function(board, name, new_version, versioned = NULL, call = caller_env()) {
   
   n_versions <- 0
+  
   if (pin_exists(board, name)) {
     versions <- pin_versions(board, name)
     n_versions <- nrow(versions)


### PR DESCRIPTION
Fixes #837.

Here is a reprex of the fix:

``` r
library(pins)

# Prepare data
write.csv(mtcars, file = "mtcars.csv")

# Create temp board and first upload
board <- board_temp(versioned = TRUE)
pin_upload(board = board, paths = "mtcars.csv", name = "data")
#> Creating new version '20240827T112516Z-cd94d'

# Returns one version
pin_versions(board, "data")
#> # A tibble: 1 × 3
#>   version                created             hash 
#>   <chr>                  <dttm>              <chr>
#> 1 20240827T112516Z-cd94d 2024-08-27 13:25:16 cd94d

# Delete just created pin
latest_version <- pin_versions(board = board, name = "data")$version
pin_version_delete(board = board, name = "data", version = latest_version)

# Returns an empty tibble
pin_versions(board, "data")
#> # A tibble: 0 × 3
#> # ℹ 3 variables: version <chr>, created <dttm>, hash <chr>

# Upload new data
pin_upload(board = board, paths = "mtcars.csv", name = "data")
#> Creating new version '20240827T112516Z-cd94d'

# Returns one version
pin_versions(board, "data")
#> # A tibble: 1 × 3
#>   version                created             hash 
#>   <chr>                  <dttm>              <chr>
#> 1 20240827T112516Z-cd94d 2024-08-27 13:25:16 cd94d
```

<sup>Created on 2024-08-27 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

I also simplified the `if` statement in `version_setup` as the solution introduced another layer of if-else statements.
If anything is missing, feel free to let me know :) 
