### PR TITLE
Do not `check_pin_name()` in `pin_upload()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Support new `preview_data` parameter for pin previews on Posit Connect (#850).
 
+* Fixed a bug in how `pin_upload()` handles pin names (#852).
+
 # pins 1.4.0
 
 ## Lifecycle changes

--- a/R/pin-upload-download.R
+++ b/R/pin-upload-download.R
@@ -57,8 +57,6 @@ pin_upload <- function(board,
   if (is.null(name) && length(paths) == 1) {
     name <- fs::path_file(paths)
     inform(paste0("Guessing `name = '", name, "'`"))
-  } else {
-    check_pin_name(name)
   }
 
   check_metadata(metadata)


### PR DESCRIPTION
Closes #847 

We don't need to use `check_pin_name()` in this function, because it is called in a board-specific way in each board's `pin_store` method.