### PR TITLE
rsconnect::accounts returns a zero-length data.frame and previously returned NULL

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Prepends 'https://' to Databricks host if missing (#855).
 
+* Fixed handling of `rsconnect::accounts()` results (#861).
+
 # pins 1.4.0
 
 ## Lifecycle changes

--- a/R/board_connect.R
+++ b/R/board_connect.R
@@ -722,7 +722,11 @@ board_connect_test <- function(...) {
 # Use demo.posit.team PTD for local testing
 connect_has_ptd <- function() {
   accounts <- rsconnect::accounts()
-  "pub.demo.posit.team" %in% accounts$server
+  if (is.null(accounts) || nrow(accounts) == 0) {
+    FALSE
+  } else {
+    "pub.demo.posit.team" %in% accounts$server
+  }
 }
 
 board_connect_ptd <- function(...) {

--- a/R/board_connect_server.R
+++ b/R/board_connect_server.R
@@ -60,14 +60,18 @@ rsc_server_manual <- function(server, key) {
 }
 
 rsc_rsconnect_is_configured <- function() {
-  is_installed("rsconnect") && !is.null(rsconnect::accounts())
+  if (is_installed("rsconnect")) {
+    accounts <- rsconnect::accounts()
+    return(!is.null(accounts) && nrow(accounts) > 0)
+  }
+  FALSE
 }
 
 rsc_server_rsconnect <- function(server = NULL, name = NULL) {
   check_installed("rsconnect")
 
   accounts <- rsconnect::accounts()
-  if (is.null(accounts)) {
+  if (is.null(accounts) || nrow(accounts) == 0) {
     abort("No Posit Connect servers have been registered")
   }
 


### PR DESCRIPTION
fixes #861