### PR TITLE
Add support of the `qs2` format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,6 +58,7 @@ Suggests:
     openssl,
     paws.storage,
     qs,
+    qs2,
     R.utils,
     rmarkdown,
     rsconnect,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # pins (development version)
 
+* Added support of the `qs2` format (#865)
+
 # pins 1.4.1
 
 * Support new `preview_data` parameter for pin previews on Posit Connect (#850).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # pins (development version)
 
-* Added support of the `qs2` format (#865)
+* Added support of the `qs2` format (#865, @atsyplenkov).
 
 # pins 1.4.1
 

--- a/R/board_connect_bundle.R
+++ b/R/board_connect_bundle.R
@@ -62,7 +62,7 @@ rsc_bundle_preview_index <- function(board, name, x, metadata, preview_data = TR
     data_preview_style = if ( is.data.frame(x) && preview_data ) "" else "display:none",
     urls = paste0("<a href=\"", metadata$urls, "\">", metadata$urls, "</a>", collapse = ", "),
     url_preview_style = if (!is.null(metadata$urls)) "" else "display:none",
-    show_python_style = if (metadata$type %in% c("rds", "qs")) "display:none" else "",
+    show_python_style = if (metadata$type %in% c("rds", "qs", "qs2")) "display:none" else "",
     pin_name = paste0(owner, "/", name$name),
     pin_metadata = list(
       as_yaml = yaml::as.yaml(metadata),

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -56,10 +56,10 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #'   When retrieving the pin, this will be stored in the `user` key, to
 #'   avoid potential clashes with the metadata that pins itself uses.
 #' @param type File type used to save `x` to disk. Must be one of
-#'   "csv", "json", "rds", "parquet", "arrow", "qs" or "qs2". If not supplied, will
+#'   "csv", "json", "rds", "parquet", "arrow", "qs", or "qs2". If not supplied, will
 #'   use JSON for bare lists and RDS for everything else. Be aware that CSV and
 #'   JSON are plain text formats, while RDS, Parquet, Arrow,
-#'   [qs](https://CRAN.R-project.org/package=qs) and
+#'   [qs](https://CRAN.R-project.org/package=qs), and
 #'   [qs2](https://CRAN.R-project.org/package=qs2)
 #'   are binary formats.
 #' @param versioned Should the pin be versioned? The default, `NULL`, will
@@ -88,6 +88,14 @@ pin_write <- function(board, x,
   dots <- list2(...)
   if (!missing(...) && (is.null(names(dots)) || names(dots)[[1]] == "")) {
     cli::cli_abort('Arguments after the dots `...` must be named, like {.code type = "json"}.')
+  }
+  if (!is_null(type) && type == "qs") {
+    lifecycle::deprecate_soft(
+      when = "1.4.2",
+      what = I('The file type "qs"'),
+      with = I('`type = "qs2"`'),
+      details = "The `qs` format will be deprecated soon: https://github.com/qsbase/qs/issues/103"
+    )
   }
 
   if (is.null(name)) {
@@ -192,15 +200,6 @@ write_rds_test <- function(x, path) {
 
 write_qs <- function(x, path) {
   check_installed("qs")
-  lifecycle::deprecate_warn(
-    when = "1.4.1.9000",
-    what = "pin_write(type = 'qs')",
-    details = paste0(
-      "The `qs` format is soon to be depreceated, ",
-      "please use the `qs2` format instead, ",
-      "i.e. `pin_write(type = 'qs2')`"
-    )
-  )
   qs::qsave(x, path)
   invisible(path)
 }

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -56,10 +56,12 @@ pin_read <- function(board, name, version = NULL, hash = NULL, ...) {
 #'   When retrieving the pin, this will be stored in the `user` key, to
 #'   avoid potential clashes with the metadata that pins itself uses.
 #' @param type File type used to save `x` to disk. Must be one of
-#'   "csv", "json", "rds", "parquet", "arrow", or "qs". If not supplied, will
+#'   "csv", "json", "rds", "parquet", "arrow", "qs" or "qs2". If not supplied, will
 #'   use JSON for bare lists and RDS for everything else. Be aware that CSV and
-#'   JSON are plain text formats, while RDS, Parquet, Arrow, and
-#'   [qs](https://CRAN.R-project.org/package=qs) are binary formats.
+#'   JSON are plain text formats, while RDS, Parquet, Arrow,
+#'   [qs](https://CRAN.R-project.org/package=qs) and
+#'   [qs2](https://CRAN.R-project.org/package=qs2)
+#'   are binary formats.
 #' @param versioned Should the pin be versioned? The default, `NULL`, will
 #'   use the default for `board`
 #' @param tags A character vector of tags for the pin; most important for
@@ -162,7 +164,8 @@ object_write <- function(x, path, type = "rds") {
     pickle = abort("'pickle' pins not supported in R"),
     joblib = abort("'joblib' pins not supported in R"),
     csv = utils::write.csv(x, path, row.names = FALSE),
-    qs = write_qs(x, path)
+    qs = write_qs(x, path),
+    qs2 = write_qs2(x, path)
   )
 
   path
@@ -189,7 +192,14 @@ write_rds_test <- function(x, path) {
 
 write_qs <- function(x, path) {
   check_installed("qs")
+  # TODO: Add deprecation warning
   qs::qsave(x, path)
+  invisible(path)
+}
+
+write_qs2 <- function(x, path) {
+  check_installed("qs2")
+  qs2::qs_save(x, path)
   invisible(path)
 }
 
@@ -205,7 +215,8 @@ write_arrow <- function(x, path) {
   invisible(path)
 }
 
-object_types <- c("rds", "json", "parquet", "arrow", "pickle", "csv", "qs", "file")
+object_types <- 
+  c("rds", "json", "parquet", "arrow", "pickle", "csv", "qs", "qs2", "file")
 
 object_read <- function(meta) {
   path <- fs::path(meta$local$dir, meta$file)
@@ -226,6 +237,7 @@ object_read <- function(meta) {
       joblib = abort("'joblib' pins not supported in R"),
       csv = utils::read.csv(path),
       qs = read_qs(path),
+      qs2 = read_qs2(path),
       file = cli_abort(c(
         "Cannot automatically read pin:",
         "*" = "Is your pin specified as a full path? Retrieve it with {.code pin_download()}",
@@ -248,6 +260,11 @@ object_read <- function(meta) {
 read_qs <- function(path) {
   check_installed("qs")
   qs::qread(path, strict = TRUE)
+}
+
+read_qs2 <- function(path) {
+  check_installed("qs2")
+  qs2::qs_read(path) # TODO: check the behaviour of qs_read if the path is invalid
 }
 
 read_parquet <- function(path) {

--- a/R/pin-read-write.R
+++ b/R/pin-read-write.R
@@ -192,7 +192,15 @@ write_rds_test <- function(x, path) {
 
 write_qs <- function(x, path) {
   check_installed("qs")
-  # TODO: Add deprecation warning
+  lifecycle::deprecate_warn(
+    when = "1.4.1.9000",
+    what = "pin_write(type = 'qs')",
+    details = paste0(
+      "The `qs` format is soon to be depreceated, ",
+      "please use the `qs2` format instead, ",
+      "i.e. `pin_write(type = 'qs2')`"
+    )
+  )
   qs::qsave(x, path)
   invisible(path)
 }
@@ -264,7 +272,7 @@ read_qs <- function(path) {
 
 read_qs2 <- function(path) {
   check_installed("qs2")
-  qs2::qs_read(path) # TODO: check the behaviour of qs_read if the path is invalid
+  qs2::qs_read(path)
 }
 
 read_parquet <- function(path) {

--- a/man/pin_read.Rd
+++ b/man/pin_read.Rd
@@ -40,10 +40,12 @@ you expect. You can find the hash of an existing pin by looking for
 \item{x}{An object (typically a data frame) to pin.}
 
 \item{type}{File type used to save \code{x} to disk. Must be one of
-"csv", "json", "rds", "parquet", "arrow", or "qs". If not supplied, will
+"csv", "json", "rds", "parquet", "arrow", "qs" or "qs2". If not supplied, will
 use JSON for bare lists and RDS for everything else. Be aware that CSV and
-JSON are plain text formats, while RDS, Parquet, Arrow, and
-\href{https://CRAN.R-project.org/package=qs}{qs} are binary formats.}
+JSON are plain text formats, while RDS, Parquet, Arrow,
+\href{https://CRAN.R-project.org/package=qs}{qs} and
+\href{https://CRAN.R-project.org/package=qs2}{qs2}
+are binary formats.}
 
 \item{title}{A title for the pin; most important for shared boards so that
 others can understand what the pin contains. If omitted, a brief

--- a/tests/testthat/_snaps/pin-read-write.md
+++ b/tests/testthat/_snaps/pin-read-write.md
@@ -29,7 +29,7 @@
       pin_write(board, mtcars, name = "mtcars", type = "froopy-loops")
     Condition
       Error in `object_write()`:
-      ! `type` must be one of "rds", "json", "parquet", "arrow", "pickle", "csv", or "qs", not "froopy-loops".
+      ! `type` must be one of "rds", "json", "parquet", "arrow", "pickle", "csv", "qs", or "qs2", not "froopy-loops".
     Code
       pin_write(board, mtcars, name = "mtcars", metadata = 1)
     Condition

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -25,8 +25,9 @@ test_that("can round trip all types", {
   pin_write(board, df, "df-4", type = "csv")
   expect_equal(pin_read(board, "df-4"), as.data.frame(df))
 
-  pin_write(board, df, "df-5", type = "qs")
-  expect_equal(pin_read(board, "df-5"), df)
+  expect_warning(
+    pin_write(board, df, "df-5", type = "qs")
+  )
 
   pin_write(board, df, "df-6", type = "qs2")
   expect_equal(pin_read(board, "df-6"), df)

--- a/tests/testthat/test-pin-read-write.R
+++ b/tests/testthat/test-pin-read-write.R
@@ -1,5 +1,6 @@
 test_that("can round trip all types", {
   skip_if_not_installed("qs")
+  skip_if_not_installed("qs2")
   skip_if_not_installed("arrow")
   skip_if_not_installed("nanoparquet")
   board <- board_temp()
@@ -26,6 +27,9 @@ test_that("can round trip all types", {
 
   pin_write(board, df, "df-5", type = "qs")
   expect_equal(pin_read(board, "df-5"), df)
+
+  pin_write(board, df, "df-6", type = "qs2")
+  expect_equal(pin_read(board, "df-6"), df)
 
   # List
   x <- list(a = 1:5, b = 1:10)

--- a/vignettes/pins.Rmd
+++ b/vignettes/pins.Rmd
@@ -77,7 +77,7 @@ But you can choose another option depending on your goals:
 -   `type = "arrow"` uses `arrow::write_feather()` to create an Arrow/Feather file.
 -   `type = "json"` uses `jsonlite::write_json()` to create a JSON file. Pretty much every programming language can read json files, but they only work well for nested lists.
 -   `type = "qs"` uses `qs::qsave()` to create a binary R data file, like `writeRDS()`. This format achieves faster read/write speeds than RDS, and compresses data more efficiently, making it a good choice for larger objects. Read more on the [qs package](https://github.com/qsbase/qs).
--   `type = "qs2"` uses `qs2::qs_save()` to create a binary R data file, like `qs::qsave()`. The [qs2](https://github.com/qsbase/qs2) format is the successor to the [qs package](https://github.com/qsbase/qs), but not compatible with the original `qs` format.
+-   `type = "qs2"` uses `qs2::qs_save()` to create a binary R data file, similar to `type = "qs"`. The [qs2](https://github.com/qsbase/qs2) format is the successor to the [qs package](https://github.com/qsbase/qs), but is not compatible with the original `qs` format.
 
 Note that when the data lives elsewhere, pins takes care of downloading and caching so that it's only re-downloaded when needed.
 That said, most boards transmit pins over HTTP, and this is going to be slow and possibly unreliable for very large pins.

--- a/vignettes/pins.Rmd
+++ b/vignettes/pins.Rmd
@@ -77,6 +77,7 @@ But you can choose another option depending on your goals:
 -   `type = "arrow"` uses `arrow::write_feather()` to create an Arrow/Feather file.
 -   `type = "json"` uses `jsonlite::write_json()` to create a JSON file. Pretty much every programming language can read json files, but they only work well for nested lists.
 -   `type = "qs"` uses `qs::qsave()` to create a binary R data file, like `writeRDS()`. This format achieves faster read/write speeds than RDS, and compresses data more efficiently, making it a good choice for larger objects. Read more on the [qs package](https://github.com/qsbase/qs).
+-   `type = "qs2"` uses `qs2::qs_save()` to create a binary R data file, like `qs::qsave()`. The [qs2](https://github.com/qsbase/qs2) format is the successor to the [qs package](https://github.com/qsbase/qs), but not compatible with the original `qs` format.
 
 Note that when the data lives elsewhere, pins takes care of downloading and caching so that it's only re-downloaded when needed.
 That said, most boards transmit pins over HTTP, and this is going to be slow and possibly unreliable for very large pins.


### PR DESCRIPTION
Hey,

This PR introduces the `qs2` format, the successor to the `qs`, as proposed in #865. In a nutshell, it adds:
* a new family of functions, `read_qs2()` and `write_qs2()`
* updated documentation and tests
* a deprecation warning for the `qs` format.

I am unsure about the latter, as the lifecycle of the `qs` package is unclear to me. However, it will certainly be deprecated in the foreseeable future; the only unknown is when. See https://github.com/qsbase/qs/issues/103